### PR TITLE
Add fourmolu workflow

### DIFF
--- a/.github/workflows/fourmolu.yaml
+++ b/.github/workflows/fourmolu.yaml
@@ -1,0 +1,38 @@
+name: Fourmolu
+
+concurrency:
+  group: ${{ github.ref }}-fourmolu
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - fourmolu.yaml
+      - "**/*.hs"
+      - ".github/workflows/fourmolu.yaml"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
+  push:
+    branches:
+      - master
+    paths:
+      - fourmolu.yaml
+      - "**/*.hs"
+      - ".github/workflows/fourmolu.yaml"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
+        name: Checkout
+      - uses: fourmolu/fourmolu-action@d88033a61a1d2f04072cabd6a0bd1308d92238e4
+        name: Run fourmolu

--- a/scripts/PsbtSignTest.hs
+++ b/scripts/PsbtSignTest.hs
@@ -1,11 +1,11 @@
 module Main (main) where
 
+import Bitcoin (PartiallySignedTransaction, SecKey)
+import qualified Bitcoin as H
 import qualified Data.ByteString as BS
 import Data.Maybe (fromMaybe)
 import qualified Data.Serialize as S
 import Data.Text (pack)
-import Bitcoin (PartiallySignedTransaction, SecKey)
-import qualified Bitcoin as H
 import System.Environment (getArgs)
 
 

--- a/src/Bitcoin.hs
+++ b/src/Bitcoin.hs
@@ -27,3 +27,4 @@ import Bitcoin.Network as Network
 import Bitcoin.Script as Script
 import Bitcoin.Transaction as Transaction
 import Bitcoin.Util as Util
+

--- a/src/Bitcoin/Address.hs
+++ b/src/Bitcoin/Address.hs
@@ -46,6 +46,13 @@ module Bitcoin.Address (
     module Bitcoin.Address.Bech32,
 ) where
 
+import Bitcoin.Address.Base58
+import Bitcoin.Address.Bech32
+import Bitcoin.Crypto
+import Bitcoin.Data
+import Bitcoin.Keys.Common
+import Bitcoin.Script
+import Bitcoin.Util
 import Control.Applicative
 import Control.Arrow (second)
 import Control.DeepSeq
@@ -66,13 +73,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Word (Word8)
 import GHC.Generics (Generic)
-import Bitcoin.Address.Base58
-import Bitcoin.Address.Bech32
-import Bitcoin.Crypto
-import Bitcoin.Data
-import Bitcoin.Keys.Common
-import Bitcoin.Script
-import Bitcoin.Util
 
 
 -- | Address format for Bitcoin

--- a/src/Bitcoin/Address/Base58.hs
+++ b/src/Bitcoin/Address/Base58.hs
@@ -14,6 +14,8 @@ module Bitcoin.Address.Base58 (
     decodeBase58Check,
 ) where
 
+import Bitcoin.Crypto.Hash
+import Bitcoin.Util
 import Control.Monad
 import Data.Array
 import Data.ByteString (ByteString)
@@ -28,8 +30,6 @@ import Data.String.Conversions (cs)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Word
-import Bitcoin.Crypto.Hash
-import Bitcoin.Util
 import Numeric (readInt, showIntAtBase)
 
 

--- a/src/Bitcoin/Block.hs
+++ b/src/Bitcoin/Block.hs
@@ -12,3 +12,4 @@ module Bitcoin.Block (
 import Bitcoin.Block.Common
 import Bitcoin.Block.Headers
 import Bitcoin.Block.Merkle
+

--- a/src/Bitcoin/Block/Common.hs
+++ b/src/Bitcoin/Block/Common.hs
@@ -26,6 +26,10 @@ module Bitcoin.Block.Common (
     encodeCompact,
 ) where
 
+import Bitcoin.Crypto.Hash
+import Bitcoin.Network.Common
+import Bitcoin.Transaction.Common
+import Bitcoin.Util
 import Control.DeepSeq
 import Control.Monad (forM_, liftM2, mzero, replicateM, (<=<))
 import Data.Aeson (
@@ -66,10 +70,6 @@ import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import Bitcoin.Crypto.Hash
-import Bitcoin.Network.Common
-import Bitcoin.Transaction.Common
-import Bitcoin.Util
 import qualified Text.Read as R
 
 

--- a/src/Bitcoin/Block/Headers.hs
+++ b/src/Bitcoin/Block/Headers.hs
@@ -60,6 +60,11 @@ module Bitcoin.Block.Headers (
     lastSmallerOrEqual,
 ) where
 
+import Bitcoin.Block.Common
+import Bitcoin.Crypto
+import Bitcoin.Data
+import Bitcoin.Transaction.Genesis
+import Bitcoin.Util
 import Control.Applicative ((<|>))
 import Control.DeepSeq
 import Control.Monad (guard, mzero, unless, when)
@@ -97,11 +102,6 @@ import Data.Serialize (Serialize (..))
 import Data.Typeable (Typeable)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
-import Bitcoin.Block.Common
-import Bitcoin.Crypto
-import Bitcoin.Data
-import Bitcoin.Transaction.Genesis
-import Bitcoin.Util
 
 
 -- | Short version of the block hash. Uses the good end of the hash (the part

--- a/src/Bitcoin/Block/Merkle.hs
+++ b/src/Bitcoin/Block/Merkle.hs
@@ -29,6 +29,11 @@ module Bitcoin.Block.Merkle (
     boolsToWord8,
 ) where
 
+import Bitcoin.Block.Common
+import Bitcoin.Crypto.Hash
+import Bitcoin.Data
+import Bitcoin.Network.Common
+import Bitcoin.Transaction.Common
 import Control.DeepSeq
 import Control.Monad (forM_, replicateM, when)
 import Data.Binary (Binary (..))
@@ -43,11 +48,6 @@ import Data.Maybe
 import Data.Serialize (Serialize (..))
 import Data.Word (Word32, Word8)
 import GHC.Generics
-import Bitcoin.Block.Common
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Network.Common
-import Bitcoin.Transaction.Common
 
 
 -- | Hash of the block's Merkle root.

--- a/src/Bitcoin/Constants.hs
+++ b/src/Bitcoin/Constants.hs
@@ -17,6 +17,10 @@ module Bitcoin.Constants (
     netByName,
 ) where
 
+import Bitcoin.Block
+import Bitcoin.Data
+import Bitcoin.Network.Common
+import Bitcoin.Transaction
 import Control.DeepSeq
 import Data.Binary (Binary (..))
 import Data.ByteString (ByteString)
@@ -30,10 +34,6 @@ import Data.String
 import Data.Text (Text)
 import Data.Word (Word32, Word64, Word8)
 import GHC.Generics (Generic)
-import Bitcoin.Block
-import Bitcoin.Data
-import Bitcoin.Network.Common
-import Bitcoin.Transaction
 import Text.Read
 
 

--- a/src/Bitcoin/Crypto.hs
+++ b/src/Bitcoin/Crypto.hs
@@ -9,6 +9,7 @@ module Bitcoin.Crypto (
     module Secp256k1,
 ) where
 
-import Crypto.Secp256k1 as Secp256k1
 import Bitcoin.Crypto.Hash as Hash
 import Bitcoin.Crypto.Signature as Signature
+import Crypto.Secp256k1 as Secp256k1
+

--- a/src/Bitcoin/Crypto/Signature.hs
+++ b/src/Bitcoin/Crypto/Signature.hs
@@ -17,6 +17,7 @@ module Bitcoin.Crypto.Signature (
     exportSig,
 ) where
 
+import Bitcoin.Crypto.Hash
 import Control.Monad (guard, unless, when)
 import Crypto.Secp256k1
 import Data.Binary (Binary (..))
@@ -27,7 +28,6 @@ import Data.Bytes.Put
 import Data.Bytes.Serial
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Serialize (Serialize (..))
-import Bitcoin.Crypto.Hash
 import Numeric (showHex)
 
 

--- a/src/Bitcoin/Data.hs
+++ b/src/Bitcoin/Data.hs
@@ -5,6 +5,7 @@ module Bitcoin.Data (
     Network (..),
 ) where
 
+import Bitcoin.Block.Common
 import Control.DeepSeq
 import Data.Binary (Binary (..))
 import Data.ByteString (ByteString)
@@ -17,7 +18,6 @@ import Data.String
 import Data.Text (Text)
 import Data.Word (Word32, Word64, Word8)
 import GHC.Generics (Generic)
-import Bitcoin.Block.Common
 import Text.Read
 
 

--- a/src/Bitcoin/Keys.hs
+++ b/src/Bitcoin/Keys.hs
@@ -13,3 +13,4 @@ module Bitcoin.Keys (
 import Bitcoin.Keys.Common
 import Bitcoin.Keys.Extended
 import Bitcoin.Keys.Mnemonic
+

--- a/src/Bitcoin/Keys/Common.hs
+++ b/src/Bitcoin/Keys/Common.hs
@@ -31,6 +31,10 @@ module Bitcoin.Keys.Common (
     toWif,
 ) where
 
+import Bitcoin.Address.Base58
+import Bitcoin.Crypto.Hash
+import Bitcoin.Data
+import Bitcoin.Util
 import Control.DeepSeq
 import Control.Monad (guard, mzero, (<=<))
 import Crypto.Secp256k1
@@ -55,10 +59,6 @@ import Data.Serialize (Serialize (..))
 import Data.String (IsString, fromString)
 import Data.String.Conversions (cs)
 import GHC.Generics (Generic)
-import Bitcoin.Address.Base58
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Util
 
 
 -- | Elliptic curve public key type with expected serialized compression flag.

--- a/src/Bitcoin/Keys/Extended.hs
+++ b/src/Bitcoin/Keys/Extended.hs
@@ -100,6 +100,17 @@ module Bitcoin.Keys.Extended (
     concatBip32Segments,
 ) where
 
+import Bitcoin.Address
+import Bitcoin.Crypto.Hash
+import Bitcoin.Data
+import Bitcoin.Keys.Common
+import Bitcoin.Keys.Extended.Internal (
+    Fingerprint (..),
+    fingerprintToText,
+    textToFingerprint,
+ )
+import Bitcoin.Script
+import Bitcoin.Util
 import Control.Applicative
 import Control.DeepSeq
 import Control.Exception (Exception, throw)
@@ -135,17 +146,6 @@ import qualified Data.Text as Text
 import Data.Typeable (Typeable)
 import Data.Word (Word32, Word8)
 import GHC.Generics (Generic)
-import Bitcoin.Address
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Keys.Common
-import Bitcoin.Keys.Extended.Internal (
-    Fingerprint (..),
-    fingerprintToText,
-    textToFingerprint,
- )
-import Bitcoin.Script
-import Bitcoin.Util
 import Text.Read as R
 import Text.Read.Lex
 

--- a/src/Bitcoin/Keys/Extended/Internal.hs
+++ b/src/Bitcoin/Keys/Extended/Internal.hs
@@ -7,6 +7,7 @@ module Bitcoin.Keys.Extended.Internal (
     textToFingerprint,
 ) where
 
+import Bitcoin.Util (decodeHex, encodeHex)
 import Control.DeepSeq (NFData)
 import Control.Monad ((>=>))
 import Data.Aeson (
@@ -31,7 +32,6 @@ import qualified Data.Text as Text
 import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import Bitcoin.Util (decodeHex, encodeHex)
 import Text.Read (readEither, readPrec)
 
 

--- a/src/Bitcoin/Keys/Mnemonic.hs
+++ b/src/Bitcoin/Keys/Mnemonic.hs
@@ -16,6 +16,7 @@ module Bitcoin.Keys.Mnemonic (
     mnemonicToSeed,
 ) where
 
+import Bitcoin.Util
 import Control.Monad (when)
 import Crypto.Hash (SHA256 (..), hashWith)
 import Crypto.KDF.PBKDF2 (Parameters (..), fastPBKDF2_SHA512)
@@ -32,7 +33,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as V
-import Bitcoin.Util
 
 
 -- | Random data used to create a mnemonic sentence. Use a good entropy source.

--- a/src/Bitcoin/Network.hs
+++ b/src/Bitcoin/Network.hs
@@ -14,3 +14,4 @@ module Bitcoin.Network (
 import Bitcoin.Network.Bloom as Bloom
 import Bitcoin.Network.Common as Common
 import Bitcoin.Network.Message as Message
+

--- a/src/Bitcoin/Network/Bloom.hs
+++ b/src/Bitcoin/Network/Bloom.hs
@@ -25,6 +25,9 @@ module Bitcoin.Network.Bloom (
     bloomRelevantUpdate,
 ) where
 
+import Bitcoin.Network.Common
+import Bitcoin.Script.Standard
+import Bitcoin.Transaction.Common
 import Control.DeepSeq
 import Control.Monad (forM_, replicateM)
 import Data.Binary (Binary (..))
@@ -41,9 +44,6 @@ import qualified Data.Sequence as S
 import Data.Serialize (Serialize (..))
 import Data.Word
 import GHC.Generics (Generic)
-import Bitcoin.Network.Common
-import Bitcoin.Script.Standard
-import Bitcoin.Transaction.Common
 
 
 -- | 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%

--- a/src/Bitcoin/Network/Common.hs
+++ b/src/Bitcoin/Network/Common.hs
@@ -41,6 +41,7 @@ module Bitcoin.Network.Common (
     putVarInt,
 ) where
 
+import Bitcoin.Crypto.Hash
 import Control.DeepSeq
 import Control.Monad (forM_, liftM2, replicateM, unless)
 import Data.Binary (Binary (..))
@@ -56,7 +57,6 @@ import Data.String
 import Data.String.Conversions (cs)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
-import Bitcoin.Crypto.Hash
 import Network.Socket (SockAddr (..))
 import Text.Read as R
 

--- a/src/Bitcoin/Network/Message.hs
+++ b/src/Bitcoin/Network/Message.hs
@@ -15,6 +15,13 @@ module Bitcoin.Network.Message (
     getMessage,
 ) where
 
+import Bitcoin.Block.Common
+import Bitcoin.Block.Merkle
+import Bitcoin.Crypto.Hash
+import Bitcoin.Data
+import Bitcoin.Network.Bloom
+import Bitcoin.Network.Common
+import Bitcoin.Transaction.Common
 import Control.DeepSeq
 import Control.Monad (unless)
 import Data.Binary (Binary (..))
@@ -26,13 +33,6 @@ import Data.Bytes.Serial
 import Data.Serialize (Serialize (..))
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import Bitcoin.Block.Common
-import Bitcoin.Block.Merkle
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Network.Bloom
-import Bitcoin.Network.Common
-import Bitcoin.Transaction.Common
 
 
 -- | Data type representing the header of a 'Message'. All messages sent between

--- a/src/Bitcoin/Script.hs
+++ b/src/Bitcoin/Script.hs
@@ -14,3 +14,4 @@ module Bitcoin.Script (
 import Bitcoin.Script.Common as Common
 import Bitcoin.Script.SigHash as SigHash
 import Bitcoin.Script.Standard as Standard
+

--- a/src/Bitcoin/Script/Common.hs
+++ b/src/Bitcoin/Script/Common.hs
@@ -207,8 +207,8 @@ data ScriptOp
     | OP_NOP8
     | OP_NOP9
     | OP_NOP10
-    -- BIP 342 (Tapscript)
-    | OP_CHECKSIGADD
+    | -- BIP 342 (Tapscript)
+      OP_CHECKSIGADD
     | -- Other
       OP_PUBKEYHASH
     | OP_PUBKEY

--- a/src/Bitcoin/Script/SigHash.hs
+++ b/src/Bitcoin/Script/SigHash.hs
@@ -27,6 +27,13 @@ module Bitcoin.Script.SigHash (
     decodeTxSig,
 ) where
 
+import Bitcoin.Crypto
+import Bitcoin.Crypto.Hash
+import Bitcoin.Data
+import Bitcoin.Network.Common
+import Bitcoin.Script.Common
+import Bitcoin.Transaction.Common
+import Bitcoin.Util
 import Control.DeepSeq
 import Control.Monad
 import qualified Data.Aeson as J
@@ -40,13 +47,6 @@ import Data.Maybe
 import Data.Scientific
 import Data.Word
 import GHC.Generics (Generic)
-import Bitcoin.Crypto
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Network.Common
-import Bitcoin.Script.Common
-import Bitcoin.Transaction.Common
-import Bitcoin.Util
 
 
 -- | Constant representing a SIGHASH flag that controls what is being signed.

--- a/src/Bitcoin/Script/Standard.hs
+++ b/src/Bitcoin/Script/Standard.hs
@@ -41,6 +41,12 @@ module Bitcoin.Script.Standard (
     isScriptHashInput,
 ) where
 
+import Bitcoin.Crypto
+import Bitcoin.Data
+import Bitcoin.Keys.Common
+import Bitcoin.Script.Common
+import Bitcoin.Script.SigHash
+import Bitcoin.Util
 import Control.Applicative ((<|>))
 import Control.DeepSeq
 import Control.Monad (guard, liftM2, (<=<))
@@ -57,12 +63,6 @@ import Data.List (sortBy)
 import Data.Maybe (fromJust, isJust)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
-import Bitcoin.Crypto
-import Bitcoin.Data
-import Bitcoin.Keys.Common
-import Bitcoin.Script.Common
-import Bitcoin.Script.SigHash
-import Bitcoin.Util
 
 
 -- | Data type describing standard transaction output scripts. Output scripts

--- a/src/Bitcoin/Transaction.hs
+++ b/src/Bitcoin/Transaction.hs
@@ -18,3 +18,4 @@ import Bitcoin.Transaction.Genesis as Genesis
 import Bitcoin.Transaction.Partial as Partial
 import Bitcoin.Transaction.Segwit as Segwit
 import Bitcoin.Transaction.Taproot as Taproot
+

--- a/src/Bitcoin/Transaction/Builder/Sign.hs
+++ b/src/Bitcoin/Transaction/Builder/Sign.hs
@@ -19,6 +19,20 @@ module Bitcoin.Transaction.Builder.Sign (
     sigKeys,
 ) where
 
+import Bitcoin.Address (getAddrHash160, pubKeyAddr)
+import Bitcoin.Crypto (Hash256, SecKey)
+import Bitcoin.Crypto.Signature (signHash, verifyHashSig)
+import Bitcoin.Data (Network)
+import Bitcoin.Keys.Common (
+    PubKeyI (..),
+    SecKeyI (..),
+    derivePubKeyI,
+    wrapSecKey,
+ )
+import Bitcoin.Script
+import Bitcoin.Transaction.Common
+import Bitcoin.Transaction.Segwit
+import Bitcoin.Util (matchTemplate, updateIndex)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM, when)
 import Data.Aeson (
@@ -46,20 +60,6 @@ import Data.Maybe (
  )
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import Bitcoin.Address (getAddrHash160, pubKeyAddr)
-import Bitcoin.Crypto (Hash256, SecKey)
-import Bitcoin.Crypto.Signature (signHash, verifyHashSig)
-import Bitcoin.Data (Network)
-import Bitcoin.Keys.Common (
-    PubKeyI (..),
-    SecKeyI (..),
-    derivePubKeyI,
-    wrapSecKey,
- )
-import Bitcoin.Script
-import Bitcoin.Transaction.Common
-import Bitcoin.Transaction.Segwit
-import Bitcoin.Util (matchTemplate, updateIndex)
 
 
 -- | Data type used to specify the signing parameters of a transaction input.

--- a/src/Bitcoin/Transaction/Common.hs
+++ b/src/Bitcoin/Transaction/Common.hs
@@ -24,6 +24,9 @@ module Bitcoin.Transaction.Common (
     nullOutPoint,
 ) where
 
+import Bitcoin.Crypto.Hash
+import Bitcoin.Network.Common
+import Bitcoin.Util
 import Control.Applicative ((<|>))
 import Control.DeepSeq
 import Control.Monad (
@@ -54,9 +57,6 @@ import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
-import Bitcoin.Crypto.Hash
-import Bitcoin.Network.Common
-import Bitcoin.Util
 import Text.Read as R
 
 

--- a/src/Bitcoin/Transaction/Genesis.hs
+++ b/src/Bitcoin/Transaction/Genesis.hs
@@ -13,10 +13,10 @@ module Bitcoin.Transaction.Genesis (
     genesisTx,
 ) where
 
-import Data.String (fromString)
 import Bitcoin.Script.Standard
 import Bitcoin.Transaction.Common
 import Bitcoin.Util
+import Data.String (fromString)
 
 
 -- | Transaction from Genesis block.

--- a/src/Bitcoin/Transaction/Taproot.hs
+++ b/src/Bitcoin/Transaction/Taproot.hs
@@ -25,6 +25,12 @@ module Bitcoin.Transaction.Taproot (
     verifyScriptPathData,
 ) where
 
+import Bitcoin.Crypto (PubKey, initTaggedHash, tweak, tweakAddPubKey)
+import Bitcoin.Keys.Common (PubKeyI (PubKeyI), pubKeyPoint)
+import Bitcoin.Script.Common (Script)
+import Bitcoin.Script.Standard (ScriptOutput (PayWitness))
+import Bitcoin.Transaction.Common (WitnessStack)
+import Bitcoin.Util (decodeHex, eitherToMaybe, encodeHex)
 import Control.Applicative (many)
 import Control.Monad ((<=<))
 import Crypto.Hash (
@@ -50,12 +56,6 @@ import Data.Foldable (foldl')
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Serialize (Serialize, get, getByteString, getWord8, put)
 import Data.Word (Word8)
-import Bitcoin.Crypto (PubKey, initTaggedHash, tweak, tweakAddPubKey)
-import Bitcoin.Keys.Common (PubKeyI (PubKeyI), pubKeyPoint)
-import Bitcoin.Script.Common (Script)
-import Bitcoin.Script.Standard (ScriptOutput (PayWitness))
-import Bitcoin.Transaction.Common (WitnessStack)
-import Bitcoin.Util (decodeHex, eitherToMaybe, encodeHex)
 
 
 -- | An x-only pubkey corresponds to the keys @(x,y)@ and @(x, -y)@.  The

--- a/src/Bitcoin/Util/Arbitrary.hs
+++ b/src/Bitcoin/Util/Arbitrary.hs
@@ -16,3 +16,4 @@ import Bitcoin.Util.Arbitrary.Network as X
 import Bitcoin.Util.Arbitrary.Script as X
 import Bitcoin.Util.Arbitrary.Transaction as X
 import Bitcoin.Util.Arbitrary.Util as X
+

--- a/src/Bitcoin/Util/Arbitrary/Address.hs
+++ b/src/Bitcoin/Util/Arbitrary/Address.hs
@@ -5,12 +5,12 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Address where
 
-import qualified Data.ByteString as B
 import Bitcoin.Address
 import Bitcoin.Constants
 import Bitcoin.Data
 import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Util
+import qualified Data.ByteString as B
 import Test.QuickCheck
 
 

--- a/src/Bitcoin/Util/Arbitrary/Block.hs
+++ b/src/Bitcoin/Util/Arbitrary/Block.hs
@@ -3,13 +3,13 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Block where
 
-import qualified Data.HashMap.Strict as HashMap
 import Bitcoin.Block
 import Bitcoin.Data
 import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Network
 import Bitcoin.Util.Arbitrary.Transaction
 import Bitcoin.Util.Arbitrary.Util
+import qualified Data.HashMap.Strict as HashMap
 import Test.QuickCheck
 
 

--- a/src/Bitcoin/Util/Arbitrary/Keys.hs
+++ b/src/Bitcoin/Util/Arbitrary/Keys.hs
@@ -3,15 +3,15 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Keys where
 
-import Data.Bits (clearBit)
-import Data.Coerce (coerce)
-import Data.List (foldl')
-import Data.Word (Word32)
 import Bitcoin.Crypto
 import Bitcoin.Keys.Common
 import Bitcoin.Keys.Extended
 import Bitcoin.Keys.Extended.Internal (Fingerprint (..))
 import Bitcoin.Util.Arbitrary.Crypto
+import Data.Bits (clearBit)
+import Data.Coerce (coerce)
+import Data.List (foldl')
+import Data.Word (Word32)
 import Test.QuickCheck
 
 

--- a/src/Bitcoin/Util/Arbitrary/Network.hs
+++ b/src/Bitcoin/Util/Arbitrary/Network.hs
@@ -3,12 +3,12 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Network where
 
-import qualified Data.ByteString as BS (empty, pack)
-import qualified Data.ByteString.Char8 as C8
-import Data.Word (Word16, Word32)
 import Bitcoin.Network
 import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Util
+import qualified Data.ByteString as BS (empty, pack)
+import qualified Data.ByteString.Char8 as C8
+import Data.Word (Word16, Word32)
 import Network.Socket (SockAddr (..))
 import Test.QuickCheck
 

--- a/src/Bitcoin/Util/Arbitrary/Script.hs
+++ b/src/Bitcoin/Util/Arbitrary/Script.hs
@@ -5,10 +5,6 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Script where
 
-import Crypto.Secp256k1
-import qualified Data.ByteString as B
-import Data.Maybe
-import Data.Word
 import Bitcoin.Address
 import Bitcoin.Constants
 import Bitcoin.Data
@@ -20,6 +16,10 @@ import Bitcoin.Util.Arbitrary.Address
 import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Keys
 import Bitcoin.Util.Arbitrary.Util
+import Crypto.Secp256k1
+import qualified Data.ByteString as B
+import Data.Maybe
+import Data.Word
 import Test.QuickCheck
 
 

--- a/src/Bitcoin/Util/Arbitrary/Util.hs
+++ b/src/Bitcoin/Util/Arbitrary/Util.hs
@@ -27,6 +27,8 @@ module Bitcoin.Util.Arbitrary.Util (
     genNetData,
 ) where
 
+import Bitcoin.Constants
+import Bitcoin.Data
 import Control.Monad (forM_, (<=<))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encoding as A
@@ -43,8 +45,6 @@ import Data.Time.Clock (UTCTime (..))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Typeable as T
 import Data.Word (Word32)
-import Bitcoin.Constants
-import Bitcoin.Data
 import Test.Hspec (Spec, describe, shouldBe, shouldSatisfy)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck

--- a/test/Bitcoin/Address/Bech32Spec.hs
+++ b/test/Bitcoin/Address/Bech32Spec.hs
@@ -4,6 +4,9 @@ module Bitcoin.Address.Bech32Spec (
     spec,
 ) where
 
+import Bitcoin.Address
+import Bitcoin.Address.Bech32
+import Bitcoin.Util
 import Control.Monad
 import Data.Bits (xor)
 import Data.ByteString (ByteString)
@@ -14,9 +17,6 @@ import Data.String.Conversions
 import Data.Text (Text, append, pack, snoc, uncons)
 import qualified Data.Text as T
 import Data.Word (Word8)
-import Bitcoin.Address
-import Bitcoin.Address.Bech32
-import Bitcoin.Util
 import Test.HUnit
 import Test.Hspec
 

--- a/test/Bitcoin/AddressSpec.hs
+++ b/test/Bitcoin/AddressSpec.hs
@@ -2,17 +2,17 @@
 
 module Bitcoin.AddressSpec (spec) where
 
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS (append, empty, pack)
-import Data.Maybe (fromJust, isJust)
-import Data.Text (Text)
-import qualified Data.Text as T
 import Bitcoin.Address
 import Bitcoin.Constants
 import Bitcoin.Data
 import Bitcoin.Keys
 import Bitcoin.Util
 import Bitcoin.Util.Arbitrary
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS (append, empty, pack)
+import Data.Maybe (fromJust, isJust)
+import Data.Text (Text)
+import qualified Data.Text as T
 import Test.HUnit
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/BlockSpec.hs
+++ b/test/Bitcoin/BlockSpec.hs
@@ -4,6 +4,11 @@ module Bitcoin.BlockSpec (
     spec,
 ) where
 
+import Bitcoin.Block
+import Bitcoin.Constants
+import Bitcoin.Data
+import Bitcoin.Transaction
+import Bitcoin.Util.Arbitrary
 import Control.Monad.State.Strict
 import Data.Either (fromRight)
 import Data.Maybe (fromJust)
@@ -11,11 +16,6 @@ import Data.String (fromString)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word (Word32)
-import Bitcoin.Block
-import Bitcoin.Constants
-import Bitcoin.Data
-import Bitcoin.Transaction
-import Bitcoin.Util.Arbitrary
 import Test.HUnit hiding (State)
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/Crypto/HashSpec.hs
+++ b/test/Bitcoin/Crypto/HashSpec.hs
@@ -2,6 +2,10 @@
 
 module Bitcoin.Crypto.HashSpec (spec) where
 
+import Bitcoin.Block
+import Bitcoin.Crypto
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder
@@ -16,10 +20,6 @@ import Data.String (fromString)
 import Data.String.Conversions
 import Data.Text (Text)
 import Data.Word
-import Bitcoin.Block
-import Bitcoin.Crypto
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
 import Test.HUnit
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/Crypto/SignatureSpec.hs
+++ b/test/Bitcoin/Crypto/SignatureSpec.hs
@@ -2,6 +2,15 @@
 
 module Bitcoin.Crypto.SignatureSpec (spec) where
 
+import Bitcoin.Address
+import Bitcoin.Constants
+import Bitcoin.Crypto
+import Bitcoin.Keys
+import Bitcoin.Script
+import Bitcoin.Transaction
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
+import Bitcoin.UtilSpec (readTestFile)
 import Control.Monad
 import Data.Bits (testBit)
 import Data.ByteString (ByteString)
@@ -12,15 +21,6 @@ import Data.Maybe
 import Data.Serialize as S
 import Data.String.Conversions (cs)
 import Data.Text (Text)
-import Bitcoin.Address
-import Bitcoin.Constants
-import Bitcoin.Crypto
-import Bitcoin.Keys
-import Bitcoin.Script
-import Bitcoin.Transaction
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec (readTestFile)
 import Test.HUnit
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/Keys/ExtendedSpec.hs
+++ b/test/Bitcoin/Keys/ExtendedSpec.hs
@@ -3,6 +3,12 @@
 
 module Bitcoin.Keys.ExtendedSpec (spec) where
 
+import Bitcoin.Address
+import Bitcoin.Constants
+import Bitcoin.Keys
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
+import Bitcoin.UtilSpec (customCerealID)
 import Control.Monad (forM_)
 import Data.Aeson as A
 import Data.Bits ((.&.))
@@ -16,12 +22,6 @@ import Data.String (fromString)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word (Word32)
-import Bitcoin.Address
-import Bitcoin.Constants
-import Bitcoin.Keys
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec (customCerealID)
 import Test.HUnit (Assertion, assertBool, assertEqual)
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/Keys/MnemonicSpec.hs
+++ b/test/Bitcoin/Keys/MnemonicSpec.hs
@@ -2,6 +2,9 @@
 
 module Bitcoin.Keys.MnemonicSpec (spec) where
 
+import Bitcoin.Keys
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
 import Control.Monad (zipWithM_)
 import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
@@ -12,9 +15,6 @@ import Data.Serialize (Serialize, encode)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Word (Word32, Word64)
-import Bitcoin.Keys
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
 import Test.HUnit
 import Test.Hspec
 import Test.QuickCheck hiding ((.&.))

--- a/test/Bitcoin/KeysSpec.hs
+++ b/test/Bitcoin/KeysSpec.hs
@@ -2,6 +2,14 @@
 
 module Bitcoin.KeysSpec (spec) where
 
+import Bitcoin.Address
+import Bitcoin.Constants
+import Bitcoin.Crypto
+import Bitcoin.Keys
+import Bitcoin.Script
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
+import Bitcoin.UtilSpec (readTestFile)
 import Control.Lens
 import Control.Monad
 import Data.Aeson as A
@@ -16,14 +24,6 @@ import qualified Data.Serialize as S
 import Data.String (fromString)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
-import Bitcoin.Address
-import Bitcoin.Constants
-import Bitcoin.Crypto
-import Bitcoin.Keys
-import Bitcoin.Script
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec (readTestFile)
 import Test.HUnit
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/NetworkSpec.hs
+++ b/test/Bitcoin/NetworkSpec.hs
@@ -2,12 +2,6 @@
 
 module Bitcoin.NetworkSpec (spec) where
 
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
-import Data.Maybe (fromJust)
-import Data.Text (Text)
-import Data.Word (Word32)
 import Bitcoin.Address
 import Bitcoin.Constants
 import Bitcoin.Keys
@@ -16,6 +10,12 @@ import Bitcoin.Transaction
 import Bitcoin.Util
 import Bitcoin.Util.Arbitrary
 import Bitcoin.UtilSpec (customCerealID)
+import Data.Bytes.Get
+import Data.Bytes.Put
+import Data.Bytes.Serial
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Data.Word (Word32)
 import Test.HUnit (Assertion, assertBool, assertEqual)
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/test/Bitcoin/ScriptSpec.hs
+++ b/test/Bitcoin/ScriptSpec.hs
@@ -2,6 +2,15 @@
 
 module Bitcoin.ScriptSpec (spec) where
 
+import Bitcoin.Address
+import Bitcoin.Constants
+import Bitcoin.Data
+import Bitcoin.Keys
+import Bitcoin.Script
+import Bitcoin.Transaction
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
+import Bitcoin.UtilSpec (readTestFile)
 import Control.Monad
 import Data.Aeson as A
 import Data.ByteString (ByteString)
@@ -16,15 +25,6 @@ import Data.String
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word
-import Bitcoin.Address
-import Bitcoin.Constants
-import Bitcoin.Data
-import Bitcoin.Keys
-import Bitcoin.Script
-import Bitcoin.Transaction
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec (readTestFile)
 import Test.HUnit as HUnit
 import Test.Hspec
 import Test.Hspec.QuickCheck
@@ -378,7 +378,7 @@ scriptSigSignatures =
       \41a2b1e401"
       -- Signature in input of txid
       -- fb0a1d8d34fa5537e461ac384bac761125e1bfa7fec286fa72511240fa66864d.
-      -- Strange DER sizes, but in Blockchain. Now invalid as this Bitcoin 
+      -- Strange DER sizes, but in Blockchain. Now invalid as this Bitcoin
       -- library can only decode strict signatures.
       -- "3048022200002b83d59c1d23c08efd82ee0662fec23309c3adbcbd1f0b8695378d\
       -- \b4b14e736602220000334a96676e58b1bb01784cb7c556dd8ce1c220171904da22\

--- a/test/Bitcoin/Transaction/PartialSpec.hs
+++ b/test/Bitcoin/Transaction/PartialSpec.hs
@@ -2,6 +2,16 @@
 
 module Bitcoin.Transaction.PartialSpec (spec) where
 
+import Bitcoin.Address
+import Bitcoin.Constants
+import Bitcoin.Crypto
+import Bitcoin.Data
+import Bitcoin.Keys
+import Bitcoin.Script
+import Bitcoin.Transaction
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
+import Bitcoin.UtilSpec (readTestFile)
 import Control.Monad ((<=<))
 import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
 import Data.Bifunctor (first)
@@ -17,16 +27,6 @@ import Data.Serialize as S
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
-import Bitcoin.Address
-import Bitcoin.Constants
-import Bitcoin.Crypto
-import Bitcoin.Data
-import Bitcoin.Keys
-import Bitcoin.Script
-import Bitcoin.Transaction
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec (readTestFile)
 import Test.HUnit (Assertion, assertBool, assertEqual)
 import Test.Hspec
 import Test.QuickCheck

--- a/test/Bitcoin/Transaction/TaprootSpec.hs
+++ b/test/Bitcoin/Transaction/TaprootSpec.hs
@@ -4,18 +4,6 @@
 
 module Bitcoin.Transaction.TaprootSpec (spec) where
 
-import Control.Applicative ((<|>))
-import Control.Monad (zipWithM, (<=<))
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
-import Data.Aeson.Types (Parser)
-import qualified Data.ByteArray as BA
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import Data.Bytes.Get (runGetS)
-import Data.Bytes.Put (runPutS)
-import Data.Bytes.Serial (deserialize, serialize)
-import Data.Text (Text)
-import Data.Word (Word8)
 import Bitcoin (
     MAST (..),
     PubKey,
@@ -39,6 +27,18 @@ import Bitcoin (
     verifyScriptPathData,
  )
 import Bitcoin.UtilSpec (readTestFile)
+import Control.Applicative ((<|>))
+import Control.Monad (zipWithM, (<=<))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Bytes.Get (runGetS)
+import Data.Bytes.Put (runPutS)
+import Data.Bytes.Serial (deserialize, serialize)
+import Data.Text (Text)
+import Data.Word (Word8)
 import Test.HUnit (assertBool, (@?=))
 import Test.Hspec (Spec, describe, it, runIO)
 

--- a/test/Bitcoin/UtilSpec.hs
+++ b/test/Bitcoin/UtilSpec.hs
@@ -4,6 +4,8 @@ module Bitcoin.UtilSpec (
     readTestFile,
 ) where
 
+import Bitcoin.Util
+import Bitcoin.Util.Arbitrary
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as A
 import Data.Aeson.Encoding (encodingToLazyByteString)
@@ -16,8 +18,6 @@ import Data.Map.Strict (singleton)
 import Data.Maybe
 import qualified Data.Sequence as Seq
 import Data.Serialize as S
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck


### PR DESCRIPTION
Resolves #33.

Adds fourmolu workflow using [fourmolu/fourmolu-action](https://github.com/fourmolu/fourmolu-action) fixed at version [0.8.2.0](https://github.com/fourmolu/fourmolu-action/commit/d88033a61a1d2f04072cabd6a0bd1308d92238e4). Can also push the formatting changes as part of this PR if we're happy with the current fourmolu configuration.