### PR TITLE
Cuts down serialization logic

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,3 +9,9 @@
         - "-fdefer-typed-holes"
         - "-Wno-typed-holes"
       within: []
+
+- modules:
+  - name: Data.ByteString
+    as: BS
+  - name: Data.ByteString.Lazy
+    as: BSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.1.0
+## 0.1.0 - Forked from `haskoin-core` 0.21.2
 
 ### Changed
 
-- Forked from `haskoin-core` 0.21.1
 - Removed Bitcoin Cash support
+- Stripped down serialization code

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -14,8 +14,6 @@ import qualified Data.Binary as Bin
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Proxy (Proxy (..))
-import Data.Serialize (Serialize)
-import qualified Data.Serialize as S
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
@@ -58,7 +56,7 @@ main = do
 
 roundTrip ::
     forall a.
-    (NFData a, Binary a, Serialize a) =>
+    (NFData a, Binary a) =>
     Proxy a ->
     String ->
     Text ->
@@ -70,11 +68,6 @@ roundTrip _ label xHex =
             "binary"
             [ bench "encode" $ nf Bin.encode x
             , bench "decode" $ nf binDecode xBytes
-            ]
-        , bgroup
-            "cereal"
-            [ bench "encode" $ nf S.encode x
-            , bench "decode" $ nf (S.decode @a) xBytes
             ]
         ]
   where

--- a/bitcoin.cabal
+++ b/bitcoin.cabal
@@ -104,11 +104,9 @@ library
     , base >=4.9 && <5
     , base16 >=0.3.0.1
     , binary >=0.8.8
-    , bytes >=0.17
     , bytestring >=0.10.10.0
-    , cereal >=0.5.8
     , containers >=0.6.2.1
-    , cryptonite >=0.26
+    , cryptonite >=0.30
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0
@@ -160,17 +158,13 @@ test-suite spec
     , base64 ==0.4.*
     , binary >=0.8.8
     , bitcoin
-    , bytes >=0.17
     , bytestring >=0.10.10.0
-    , cereal >=0.5.8
     , containers >=0.6.2.1
-    , cryptonite >=0.26
+    , cryptonite >=0.30
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0
     , hspec >=2.7.1
-    , lens >=4.18.1
-    , lens-aeson >=1.1
     , memory >=0.15.0
     , murmur3 >=1.0.3
     , network >=3.1.1.1
@@ -185,7 +179,6 @@ test-suite spec
     , unordered-containers >=0.2.10.0
     , vector >=0.12.1.2
   default-language: Haskell2010
-  build-tool-depends: hspec-discover:hspec-discover
 
 benchmark benchmark
   type: exitcode-stdio-1.0
@@ -201,12 +194,10 @@ benchmark benchmark
     , base16 >=0.3.0.1
     , binary >=0.8.8
     , bitcoin
-    , bytes >=0.17
     , bytestring >=0.10.10.0
-    , cereal >=0.5.8
     , containers >=0.6.2.1
     , criterion >=1.5 && <1.7
-    , cryptonite >=0.26
+    , cryptonite >=0.30
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0

--- a/package.yaml
+++ b/package.yaml
@@ -24,11 +24,9 @@ dependencies:
   - base >=4.9 && <5
   - base16 >= 0.3.0.1
   - binary >= 0.8.8
-  - bytes >= 0.17
   - bytestring >= 0.10.10.0
-  - cereal >= 0.5.8
   - containers >= 0.6.2.1
-  - cryptonite >= 0.26
+  - cryptonite >= 0.30
   - deepseq >= 1.4.4.0
   - entropy >= 0.4.1.5
   - hashable >= 1.3.0.0
@@ -57,8 +55,6 @@ tests:
   spec:
     main: Spec.hs
     source-dirs: test
-    verbatim:
-      build-tool-depends: hspec-discover:hspec-discover
     dependencies:
       - aeson >= 1.4.6.0
       - base64 ^>= 0.4
@@ -66,8 +62,6 @@ tests:
       - hspec >= 2.7.1
       - HUnit >= 1.6.0.0
       - QuickCheck >= 2.13.2
-      - lens-aeson >= 1.1
-      - lens >= 4.18.1
 benchmarks:
   benchmark:
     main: Main.hs

--- a/src/Bitcoin/Address/Bech32.hs
+++ b/src/Bitcoin/Address/Bech32.hs
@@ -49,7 +49,7 @@ import Data.Bits (
     (.&.),
     (.|.),
  )
-import qualified Data.ByteString as B
+import qualified Data.ByteString as BS
 import Data.Char (toUpper)
 import Data.Foldable (foldl')
 import Data.Functor.Identity (Identity, runIdentity)
@@ -143,7 +143,7 @@ bech32HRPExpand hrp =
         ++ [UnsafeWord5 0]
         ++ map word5 hrpBytes
   where
-    hrpBytes = B.unpack $ E.encodeUtf8 hrp
+    hrpBytes = BS.unpack $ E.encodeUtf8 hrp
 
 
 bech32Const :: Bech32Encoding -> Word

--- a/src/Bitcoin/Constants.hs
+++ b/src/Bitcoin/Constants.hs
@@ -17,24 +17,13 @@ module Bitcoin.Constants (
     netByName,
 ) where
 
-import Bitcoin.Block
-import Bitcoin.Data
-import Bitcoin.Network.Common
-import Bitcoin.Transaction
-import Control.DeepSeq
-import Data.Binary (Binary (..))
-import Data.ByteString (ByteString)
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
-import Data.List
-import Data.Maybe
-import Data.Serialize (Serialize (..))
-import Data.String
-import Data.Text (Text)
-import Data.Word (Word32, Word64, Word8)
-import GHC.Generics (Generic)
-import Text.Read
+import Bitcoin.Block.Common (BlockHeader (BlockHeader))
+import Bitcoin.Block.Merkle (buildMerkleRoot)
+import Bitcoin.Data (Network (..))
+import Bitcoin.Transaction.Common (txHash)
+import Bitcoin.Transaction.Genesis (genesisTx)
+import Data.List (find)
+import Data.String (IsString)
 
 
 -- | Version of Bitcoin package.

--- a/src/Bitcoin/Data.hs
+++ b/src/Bitcoin/Data.hs
@@ -5,20 +5,12 @@ module Bitcoin.Data (
     Network (..),
 ) where
 
-import Bitcoin.Block.Common
-import Control.DeepSeq
-import Data.Binary (Binary (..))
+import Bitcoin.Block.Common (BlockHash, BlockHeader, BlockHeight)
+import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
-import Data.List
-import Data.Serialize (Serialize (..))
-import Data.String
 import Data.Text (Text)
 import Data.Word (Word32, Word64, Word8)
 import GHC.Generics (Generic)
-import Text.Read
 
 
 -- | Network definition.

--- a/src/Bitcoin/Keys/Common.hs
+++ b/src/Bitcoin/Keys/Common.hs
@@ -31,23 +31,39 @@ module Bitcoin.Keys.Common (
     toWif,
 ) where
 
-import Bitcoin.Address.Base58
-import Bitcoin.Crypto.Hash
-import Bitcoin.Data
-import Bitcoin.Util
-import Control.DeepSeq
+import Bitcoin.Address.Base58 (
+    Base58,
+    decodeBase58Check,
+    encodeBase58Check,
+ )
+import Bitcoin.Crypto.Hash (Hash256, sha256)
+import Bitcoin.Data (Network (getSecretPrefix))
+import Bitcoin.Util (decodeHex, eitherToMaybe)
+import qualified Bitcoin.Util as U
+import Control.DeepSeq (NFData)
 import Control.Monad (guard, mzero, (<=<))
-import Crypto.Secp256k1
+import Crypto.Hash (hashWith)
+import Crypto.Hash.Algorithms (SHA256 (SHA256))
+import Crypto.Secp256k1 (
+    PubKey,
+    SecKey (..),
+    derivePubKey,
+    exportPubKey,
+    importPubKey,
+    secKey,
+    tweak,
+    tweakAddPubKey,
+    tweakAddSecKey,
+ )
 import Data.Binary (Binary (..))
+import Data.Binary.Get (getByteString, getWord8, lookAhead)
+import Data.Binary.Put (putByteString)
+import qualified Data.ByteArray as BA
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Data.ByteString.Builder (char7)
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
-import Data.Hashable
+import qualified Data.ByteString.Lazy as BSL
+import Data.Hashable (Hashable)
 import Data.Maybe (fromMaybe)
-import Data.Serialize (Serialize (..))
 import Data.String (IsString, fromString)
 import Data.String.Conversions (cs)
 import GHC.Generics (Generic)
@@ -63,13 +79,13 @@ data PubKeyI = PubKeyI
 
 instance IsString PubKeyI where
     fromString str =
-        fromMaybe e $ eitherToMaybe . runGetS deserialize <=< decodeHex $ cs str
+        fromMaybe e $ eitherToMaybe . U.decode . BSL.fromStrict =<< decodeHex (cs str)
       where
         e = error "Could not decode public key"
 
 
-instance Serial PubKeyI where
-    deserialize =
+instance Binary PubKeyI where
+    get =
         s >>= \case
             True -> c
             False -> u
@@ -91,17 +107,7 @@ instance Serial PubKeyI where
                 PubKeyI <$> importPubKey bs <*> pure False
 
 
-    serialize pk = putByteString $ exportPubKey (pubKeyCompressed pk) (pubKeyPoint pk)
-
-
-instance Serialize PubKeyI where
-    put = serialize
-    get = deserialize
-
-
-instance Binary PubKeyI where
-    put = serialize
-    get = deserialize
+    put pk = putByteString $ (exportPubKey <$> pubKeyCompressed <*> pubKeyPoint) pk
 
 
 -- | Wrap a public key from secp256k1 library adding information about compression.
@@ -117,7 +123,7 @@ derivePubKeyI (SecKeyI d c) = PubKeyI (derivePubKey d) c
 
 -- | Tweak a public key.
 tweakPubKey :: PubKey -> Hash256 -> Maybe PubKey
-tweakPubKey p h = tweakAddPubKey p =<< tweak (runPutS (serialize h))
+tweakPubKey p = tweakAddPubKey p <=< tweak . U.encodeS
 
 
 -- | Elliptic curve private key type with expected public key compression
@@ -138,16 +144,16 @@ wrapSecKey c d = SecKeyI d c
 
 -- | Tweak a private key.
 tweakSecKey :: SecKey -> Hash256 -> Maybe SecKey
-tweakSecKey key h = tweakAddSecKey key =<< tweak (runPutS (serialize h))
+tweakSecKey key = tweakAddSecKey key <=< tweak . U.encodeS
 
 
 -- | Decode Casascius mini private keys (22 or 30 characters).
 fromMiniKey :: ByteString -> Maybe SecKeyI
 fromMiniKey bs = do
     guard checkShortKey
-    wrapSecKey False <$> secKey (runPutS (serialize (sha256 bs)))
+    wrapSecKey False <$> (secKey . BA.convert . hashWith SHA256) bs
   where
-    checkHash = runPutS $ serialize $ sha256 $ bs `BS.append` "?"
+    checkHash = BA.convert . hashWith SHA256 $ bs `BS.append` "?"
     checkShortKey = BS.length bs `elem` [22, 30] && BS.head checkHash == 0x00
 
 
@@ -156,14 +162,14 @@ fromWif :: Network -> Base58 -> Maybe SecKeyI
 fromWif net wif = do
     bs <- decodeBase58Check wif
     -- Check that this is a private key
-    guard (BS.head bs == getSecretPrefix net)
-    case BS.length bs of
+    guard (BSL.head bs == getSecretPrefix net)
+    case BSL.length bs of
         -- Uncompressed format
-        33 -> wrapSecKey False <$> secKey (BS.tail bs)
+        33 -> wrapSecKey False <$> (secKey . BSL.toStrict) (BSL.tail bs)
         -- Compressed format
         34 -> do
-            guard $ BS.last bs == 0x01
-            wrapSecKey True <$> secKey (BS.tail $ BS.init bs)
+            guard $ BSL.last bs == 0x01
+            wrapSecKey True <$> (secKey . BS.tail . BS.init . BSL.toStrict) bs
         -- Bad length
         _ -> Nothing
 
@@ -171,7 +177,7 @@ fromWif net wif = do
 -- | Encode private key into a WIF string.
 toWif :: Network -> SecKeyI -> Base58
 toWif net (SecKeyI k c) =
-    encodeBase58Check . BS.cons (getSecretPrefix net) $
+    encodeBase58Check . BSL.cons (getSecretPrefix net) . BSL.fromStrict $
         if c
             then getSecKey k `BS.snoc` 0x01
             else getSecKey k

--- a/src/Bitcoin/Keys/Mnemonic.hs
+++ b/src/Bitcoin/Keys/Mnemonic.hs
@@ -24,6 +24,7 @@ import Data.Bits (shiftL, shiftR)
 import qualified Data.ByteArray as BA
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 import Data.List
 import qualified Data.Map.Strict as M
 import Data.Maybe
@@ -114,7 +115,7 @@ calcCS len = getBits len . BA.convert . hashWith SHA256
 
 numCS :: Int -> Entropy -> Integer
 numCS len =
-    shiftCS . bsToInteger
+    shiftCS . bsToInteger . BSL.fromStrict
   where
     shiftCS = case 8 - len `mod` 8 of
         8 -> id
@@ -176,7 +177,7 @@ indicesToBS is = do
 -- | Turn a 'ByteString' into a list of 11-bit numbers.
 bsToIndices :: ByteString -> [Int]
 bsToIndices bs =
-    reverse . go q $ bsToInteger bs `shiftR` r
+    reverse . go q $ bsToInteger (BSL.fromStrict bs) `shiftR` r
   where
     (q, r) = (BS.length bs * 8) `quotRem` 11
     go 0 _ = []

--- a/src/Bitcoin/Script/Standard.hs
+++ b/src/Bitcoin/Script/Standard.hs
@@ -41,22 +41,34 @@ module Bitcoin.Script.Standard (
     isScriptHashInput,
 ) where
 
-import Bitcoin.Crypto
-import Bitcoin.Data
-import Bitcoin.Keys.Common
-import Bitcoin.Script.Common
-import Bitcoin.Script.SigHash
-import Bitcoin.Util
+import Bitcoin.Crypto.Hash (Hash160, Hash256, addressHashL, sha256L)
+import Bitcoin.Data (Network)
+import Bitcoin.Keys.Common (PubKeyI)
+import Bitcoin.Script.Common (
+    PushDataType (OPCODE),
+    Script (..),
+    ScriptOp (..),
+    intToScriptOp,
+    opPushData,
+    scriptOpToInt,
+ )
+import Bitcoin.Script.SigHash (
+    TxSignature (TxSignatureEmpty),
+    decodeTxSig,
+    encodeTxSig,
+ )
+import Bitcoin.Util (eitherToMaybe, maybeToEither)
+import qualified Bitcoin.Util as U
 import Control.Applicative ((<|>))
-import Control.DeepSeq
+import Control.DeepSeq (NFData)
 import Control.Monad (guard, liftM2, (<=<))
+import Data.Binary (Binary)
+import qualified Data.Binary as Bin
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
+import qualified Data.ByteString.Lazy as BSL
 import Data.Function (on)
-import Data.Hashable
+import Data.Hashable (Hashable)
 import Data.List (sortBy)
 import Data.Maybe (fromJust, isJust)
 import Data.Word (Word8)
@@ -145,17 +157,17 @@ isDataCarrier _ = False
 decodeOutput :: Script -> Either String ScriptOutput
 decodeOutput s = case scriptOps s of
     -- Pay to PubKey
-    [OP_PUSHDATA bs _, OP_CHECKSIG] -> PayPK <$> runGetS deserialize bs
+    [OP_PUSHDATA bs _, OP_CHECKSIG] -> PayPK <$> (U.decode . BSL.fromStrict) bs
     -- Pay to PubKey Hash
     [OP_DUP, OP_HASH160, OP_PUSHDATA bs _, OP_EQUALVERIFY, OP_CHECKSIG] ->
-        PayPKHash <$> runGetS deserialize bs
+        PayPKHash <$> (U.decode . BSL.fromStrict) bs
     -- Pay to Script Hash
     [OP_HASH160, OP_PUSHDATA bs _, OP_EQUAL] ->
-        PayScriptHash <$> runGetS deserialize bs
+        PayScriptHash <$> (U.decode . BSL.fromStrict) bs
     -- Pay to Witness
     [OP_0, OP_PUSHDATA bs OPCODE]
-        | BS.length bs == 20 -> PayWitnessPKHash <$> runGetS deserialize bs
-        | BS.length bs == 32 -> PayWitnessScriptHash <$> runGetS deserialize bs
+        | BS.length bs == 20 -> PayWitnessPKHash <$> (U.decode . BSL.fromStrict) bs
+        | BS.length bs == 32 -> PayWitnessScriptHash <$> (U.decode . BSL.fromStrict) bs
         | BS.length bs /= 20 && BS.length bs /= 32 ->
             Left "Version 0 segwit program must be 20 or 32 bytes long"
     -- Other Witness
@@ -214,19 +226,20 @@ opWitnessVersion _ = Nothing
 
 -- | Similar to 'decodeOutput' but decodes from a 'ByteString'.
 decodeOutputBS :: ByteString -> Either String ScriptOutput
-decodeOutputBS = decodeOutput <=< runGetS deserialize
+decodeOutputBS = decodeOutput <=< U.decode . BSL.fromStrict
 
 
 -- | Computes a 'Script' from a standard 'ScriptOutput'.
 encodeOutput :: ScriptOutput -> Script
+-- FIXME this might be a good place to also have strict serialization of keys
 encodeOutput s = Script $ case s of
     -- Pay to PubKey
-    (PayPK k) -> [opPushData $ runPutS $ serialize k, OP_CHECKSIG]
+    (PayPK k) -> [pushItem k, OP_CHECKSIG]
     -- Pay to PubKey Hash Address
     (PayPKHash h) ->
         [ OP_DUP
         , OP_HASH160
-        , opPushData $ runPutS $ serialize h
+        , pushItem h
         , OP_EQUALVERIFY
         , OP_CHECKSIG
         ]
@@ -235,17 +248,17 @@ encodeOutput s = Script $ case s of
         | r <= length ps ->
             let opM = intToScriptOp r
                 opN = intToScriptOp $ length ps
-                keys = map (opPushData . runPutS . serialize) ps
+                keys = pushItem <$> ps
              in opM : keys ++ [opN, OP_CHECKMULTISIG]
         | otherwise -> error "encodeOutput: PayMulSig r must be <= than pkeys"
     -- Pay to Script Hash Address
     (PayScriptHash h) ->
-        [OP_HASH160, opPushData $ runPutS $ serialize h, OP_EQUAL]
+        [OP_HASH160, pushItem h, OP_EQUAL]
     -- Pay to Witness PubKey Hash Address
     (PayWitnessPKHash h) ->
-        [OP_0, opPushData $ runPutS $ serialize h]
+        [OP_0, pushItem h]
     (PayWitnessScriptHash h) ->
-        [OP_0, opPushData $ runPutS $ serialize h]
+        [OP_0, pushItem h]
     (PayWitness v h) ->
         [ case witnessVersionOp v of
             Nothing -> error "encodeOutput: invalid witness version"
@@ -256,19 +269,23 @@ encodeOutput s = Script $ case s of
     (DataCarrier d) -> [OP_RETURN, opPushData d]
 
 
+pushItem :: Binary a => a -> ScriptOp
+pushItem = opPushData . U.encodeS
+
+
 -- | Similar to 'encodeOutput' but encodes to a ByteString
 encodeOutputBS :: ScriptOutput -> ByteString
-encodeOutputBS = runPutS . serialize . encodeOutput
+encodeOutputBS = U.encodeS . encodeOutput
 
 
 -- | Encode script as pay-to-script-hash script
 toP2SH :: Script -> ScriptOutput
-toP2SH = PayScriptHash . addressHash . runPutS . serialize
+toP2SH = PayScriptHash . addressHashL . Bin.encode
 
 
 -- | Encode script as a pay-to-witness-script-hash script
 toP2WSH :: Script -> ScriptOutput
-toP2WSH = PayWitnessScriptHash . sha256 . runPutS . serialize
+toP2WSH = PayWitnessScriptHash . sha256L . Bin.encode
 
 
 -- | Match @[OP_N, PubKey1, ..., PubKeyM, OP_M, OP_CHECKMULTISIG]@
@@ -281,7 +298,7 @@ matchPayMulSig (Script ops) = case splitAt (length ops - 2) ops of
             else Left "matchPayMulSig: Invalid M or N parameters"
     _ -> Left "matchPayMulSig: script did not match output template"
   where
-    go (OP_PUSHDATA bs _ : xs) = liftM2 (:) (runGetS deserialize bs) (go xs)
+    go (OP_PUSHDATA bs _ : xs) = liftM2 (:) (U.decode $ BSL.fromStrict bs) (go xs)
     go [] = return []
     go _ = Left "matchPayMulSig: invalid multisig opcode"
 
@@ -290,7 +307,7 @@ matchPayMulSig (Script ops) = case splitAt (length ops - 2) ops of
 -- their compressed serialized representations. Refer to BIP-67.
 sortMulSig :: ScriptOutput -> ScriptOutput
 sortMulSig out = case out of
-    PayMulSig keys r -> PayMulSig (sortBy (compare `on` (runPutS . serialize)) keys) r
+    PayMulSig keys r -> PayMulSig (sortBy (compare `on` Bin.encode) keys) r
     _ -> error "Can only call orderMulSig on PayMulSig scripts"
 
 
@@ -370,7 +387,7 @@ decodeSimpleInput net (Script ops) =
     matchPK [op] = SpendPK <$> f op
     matchPK _ = Nothing
     matchPKHash [op, OP_PUSHDATA pub _] =
-        SpendPKHash <$> f op <*> eitherToMaybe (runGetS deserialize pub)
+        SpendPKHash <$> f op <*> (eitherToMaybe . U.decode . BSL.fromStrict) pub
     matchPKHash _ = Nothing
     matchMulSig (x : xs) = do
         guard $ x == OP_0
@@ -404,7 +421,7 @@ decodeInput net s@(Script ops) =
 -- | Like 'decodeInput' but decodes directly from a serialized script
 -- 'ByteString'.
 decodeInputBS :: Network -> ByteString -> Either String ScriptInput
-decodeInputBS net = decodeInput net <=< runGetS deserialize
+decodeInputBS net = decodeInput net <=< U.decode . BSL.fromStrict
 
 
 -- | Encode a standard input into a script.
@@ -419,7 +436,7 @@ encodeInput s = case s of
 -- | Similar to 'encodeInput' but encodes directly to a serialized script
 -- 'ByteString'.
 encodeInputBS :: ScriptInput -> ByteString
-encodeInputBS = runPutS . serialize . encodeInput
+encodeInputBS = U.encodeS . encodeInput
 
 
 -- | Encode a standard 'SimpleInput' into opcodes as an input 'Script'.
@@ -428,7 +445,7 @@ encodeSimpleInput s =
     Script $
         case s of
             SpendPK ts -> [f ts]
-            SpendPKHash ts p -> [f ts, opPushData $ runPutS $ serialize p]
+            SpendPKHash ts p -> [f ts, pushItem p]
             SpendMulSig xs -> OP_0 : map f xs
   where
     f TxSignatureEmpty = OP_0

--- a/src/Bitcoin/Transaction/Builder/Sign.hs
+++ b/src/Bitcoin/Transaction/Builder/Sign.hs
@@ -29,15 +29,38 @@ import Bitcoin.Keys.Common (
     derivePubKeyI,
     wrapSecKey,
  )
-import Bitcoin.Script
-import Bitcoin.Transaction.Common
-import Bitcoin.Transaction.Segwit
+import Bitcoin.Script (
+    RedeemScript,
+    ScriptInput (..),
+    ScriptOutput (..),
+    SigHash,
+    SimpleInput (..),
+    TxSignature (..),
+    decodeInputBS,
+    decodeTxSig,
+    encodeInputBS,
+    encodeOutput,
+    encodeOutputBS,
+    opPushData,
+    txSigHash,
+    txSigHashSegwitV0,
+ )
+import Bitcoin.Transaction.Common (
+    OutPoint,
+    Tx (..),
+    TxIn (..),
+    WitnessData,
+ )
+import Bitcoin.Transaction.Segwit (
+    WitnessProgram (EmptyWitnessProgram),
+    calcWitnessProgram,
+    isSegwit,
+    toWitnessStack,
+ )
 import Bitcoin.Util (matchTemplate, updateIndex)
+import qualified Bitcoin.Util as U
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM, when)
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
 import Data.Either (rights)
 import Data.Hashable (Hashable)
 import Data.List (find, nub)
@@ -118,7 +141,7 @@ signInput net tx i (sigIn@(SigInput so val _ _ rdmM), nest) key = do
             }
   where
     f si x = x{scriptInput = encodeInputBS si}
-    g so' x = x{scriptInput = runPutS . serialize . opPushData $ encodeOutputBS so'}
+    g so' x = x{scriptInput = U.encodeS . opPushData $ encodeOutputBS so'}
     txis = txIn tx
     nextTxIn so' si
         | isSegwit so' && nest = updateIndex i txis (g so')

--- a/src/Bitcoin/Util/Arbitrary/Address.hs
+++ b/src/Bitcoin/Util/Arbitrary/Address.hs
@@ -10,7 +10,7 @@ import Bitcoin.Constants
 import Bitcoin.Data
 import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Util
-import qualified Data.ByteString as B
+import qualified Data.ByteString as BS
 import Test.QuickCheck
 
 
@@ -63,5 +63,5 @@ arbitraryWitnessAddress = do
     ver <- choose (1, 16)
     len <- choose (2, 40)
     ws <- vectorOf len arbitrary
-    let bs = B.pack ws
+    let bs = BS.pack ws
     return $ WitnessAddress ver bs

--- a/src/Bitcoin/Util/Arbitrary/Crypto.hs
+++ b/src/Bitcoin/Util/Arbitrary/Crypto.hs
@@ -3,9 +3,19 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Crypto where
 
-import Bitcoin.Crypto.Hash
-import Bitcoin.Util.Arbitrary.Util
-import Test.QuickCheck
+import Bitcoin.Crypto.Hash (
+    CheckSum32,
+    Hash160,
+    Hash256,
+    Hash512,
+    checkSum32,
+    ripemd160,
+    sha256,
+    sha512,
+ )
+import Bitcoin.Util.Arbitrary.Util (arbitraryBSn)
+import qualified Data.ByteString.Lazy as BSL
+import Test.QuickCheck (Gen)
 
 
 -- | Arbitrary 160-bit hash.
@@ -29,4 +39,4 @@ arbitraryHash512 =
 -- | Arbitrary 32-bit checksum.
 arbitraryCheckSum32 :: Gen CheckSum32
 arbitraryCheckSum32 =
-    checkSum32 <$> arbitraryBSn 4
+    checkSum32 . BSL.fromStrict <$> arbitraryBSn 4

--- a/src/Bitcoin/Util/Arbitrary/Network.hs
+++ b/src/Bitcoin/Util/Arbitrary/Network.hs
@@ -3,14 +3,44 @@
 -- Portability : POSIX
 module Bitcoin.Util.Arbitrary.Network where
 
-import Bitcoin.Network
-import Bitcoin.Util.Arbitrary.Crypto
-import Bitcoin.Util.Arbitrary.Util
+import Bitcoin.Network (
+    Addr (Addr),
+    Alert (Alert),
+    BloomFilter,
+    BloomFlags (..),
+    FilterAdd (FilterAdd),
+    FilterLoad (FilterLoad),
+    GetData (GetData),
+    Inv (Inv),
+    InvType (..),
+    InvVector (InvVector),
+    MessageCommand (..),
+    NetworkAddress (NetworkAddress),
+    NotFound (NotFound),
+    Ping (Ping),
+    Pong (Pong),
+    Reject (Reject),
+    RejectCode (..),
+    VarInt (VarInt),
+    VarString (VarString),
+    Version (Version),
+    bloomCreate,
+ )
+import Bitcoin.Util.Arbitrary.Crypto (arbitraryHash256)
+import Bitcoin.Util.Arbitrary.Util (arbitraryBS)
 import qualified Data.ByteString as BS (empty, pack)
 import qualified Data.ByteString.Char8 as C8
 import Data.Word (Word16, Word32)
-import Network.Socket (SockAddr (..))
-import Test.QuickCheck
+import Test.QuickCheck (
+    ASCIIString (ASCIIString),
+    Arbitrary (arbitrary),
+    Gen,
+    choose,
+    elements,
+    listOf1,
+    oneof,
+    vectorOf,
+ )
 
 
 -- | Arbitrary 'VarInt'.
@@ -25,21 +55,15 @@ arbitraryVarString = VarString <$> arbitraryBS
 
 -- | Arbitrary 'NetworkAddress'.
 arbitraryNetworkAddress :: Gen NetworkAddress
-arbitraryNetworkAddress = do
-    s <- arbitrary
-    a <- arbitrary
-    p <- arbitrary
-    d <-
-        oneof
-            [ do
-                b <- arbitrary
-                c <- arbitrary
-                d <- arbitrary
-                return $ SockAddrInet6 (fromIntegral p) 0 (a, b, c, d) 0
-            , return $ SockAddrInet (fromIntegral (p :: Word16)) a
-            ]
-    let n = sockToHostAddress d
-    return $ NetworkAddress s n
+arbitraryNetworkAddress =
+    NetworkAddress
+        <$> arbitrary
+        <*> ( (,,,)
+                <$> arbitrary
+                <*> arbitrary
+                <*> arbitrary
+                <*> arbitrary
+            )
 
 
 -- | Arbitrary 'NetworkAddressTime'.

--- a/src/Bitcoin/Util/Arbitrary/Script.hs
+++ b/src/Bitcoin/Util/Arbitrary/Script.hs
@@ -17,7 +17,7 @@ import Bitcoin.Util.Arbitrary.Crypto
 import Bitcoin.Util.Arbitrary.Keys
 import Bitcoin.Util.Arbitrary.Util
 import Crypto.Secp256k1
-import qualified Data.ByteString as B
+import qualified Data.ByteString as BS
 import Data.Maybe
 import Data.Word
 import Test.QuickCheck
@@ -292,7 +292,7 @@ arbitraryWitOutput = do
     ver <- choose (1, 16)
     len <- choose (2, 40)
     ws <- vectorOf len arbitrary
-    let bs = B.pack ws
+    let bs = BS.pack ws
     return $ PayWitness ver bs
 
 

--- a/src/Bitcoin/Util/Arbitrary/Util.hs
+++ b/src/Bitcoin/Util/Arbitrary/Util.hs
@@ -20,24 +20,26 @@ module Bitcoin.Util.Arbitrary.Util (
     fromMap,
 ) where
 
-import Bitcoin.Constants
-import Bitcoin.Data
+import Bitcoin.Constants (Network, allNets)
 import Control.Monad (forM_, (<=<))
 import Data.ByteString (ByteString, pack)
 import Data.ByteString.Lazy (fromStrict, toStrict)
 import qualified Data.ByteString.Short as BSS
-import Data.Bytes.Get
-import Data.Bytes.Put
-import Data.Bytes.Serial
 import qualified Data.Map.Strict as Map
-import Data.Proxy
 import Data.Time.Clock (UTCTime (..))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Typeable as T
 import Data.Word (Word32)
 import Test.Hspec (Spec, describe, shouldBe, shouldSatisfy)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck
+import Test.QuickCheck (
+    Arbitrary (arbitrary),
+    Gen,
+    elements,
+    frequency,
+    listOf1,
+    vectorOf,
+ )
 
 
 -- | Arbitrary strict 'ByteString'.

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,4 @@ nix:
     - pkg-config
 extra-deps:
   - fourmolu-0.8.2.0
+  - cryptonite-0.30

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       size: 143718
   original:
     hackage: fourmolu-0.8.2.0
+- completed:
+    hackage: cryptonite-0.30@sha256:12c85dea7be63e5ad90bcb487eb3846bf3c413347f94336fa1dede7b28f9936a,18301
+    pantry-tree:
+      sha256: df1cbe4cc40d569cc75ffed40bc5deac43cb085653980b42b9b6a5d4b745a30a
+      size: 23323
+  original:
+    hackage: cryptonite-0.30
 snapshots:
 - completed:
     sha256: 1ecad1f0bd2c27de88dbff6572446cfdf647c615d58a7e2e2085c6b7dfc04176

--- a/test/Bitcoin/Address/Bech32Spec.hs
+++ b/test/Bitcoin/Address/Bech32Spec.hs
@@ -10,7 +10,7 @@ import Bitcoin.Util
 import Control.Monad
 import Data.Bits (xor)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
+import qualified Data.ByteString as BS
 import Data.Char (chr, ord, toLower)
 import Data.Maybe
 import Data.String.Conversions
@@ -120,7 +120,7 @@ testInvalidAddress address = do
 
 segwitScriptPubkey :: Word8 -> [Word8] -> ByteString
 segwitScriptPubkey witver witprog =
-    B.pack $ witver' : fromIntegral (length witprog) : witprog
+    BS.pack $ witver' : fromIntegral (length witprog) : witprog
   where
     witver' = if witver == 0 then 0 else witver + 0x50
 

--- a/test/Bitcoin/BlockSpec.hs
+++ b/test/Bitcoin/BlockSpec.hs
@@ -4,32 +4,71 @@ module Bitcoin.BlockSpec (
     spec,
 ) where
 
-import Bitcoin.Block
-import Bitcoin.Constants
-import Bitcoin.Data
+import Bitcoin.Block (
+    BlockHeader,
+    BlockHeaders,
+    BlockNode (nodeHeader, nodeHeight),
+    HeaderMemory,
+    Timestamp,
+    appendBlocks,
+    blockHashToHex,
+    buildMerkleRoot,
+    buildPartialMerkle,
+    calcTreeHeight,
+    calcTreeWidth,
+    computeAssertBits,
+    computeSubsidy,
+    connectBlocks,
+    decodeCompact,
+    encodeCompact,
+    extractMatches,
+    hexToBlockHash,
+    initialChain,
+    splitPoint,
+ )
+import Bitcoin.Constants (
+    Network (..),
+    btc,
+    btcRegTest,
+ )
 import Bitcoin.Orphans ()
-import Bitcoin.Transaction
-import Bitcoin.Util
-import Bitcoin.Util.Arbitrary
-import Bitcoin.UtilSpec hiding (spec)
-import Control.Monad (MonadPlus (..), forM_, unless, (<=<))
-import Control.Monad.Trans.State.Strict
-import Data.Aeson
-import Data.Aeson.Encoding
-import qualified Data.ByteString.Lazy as BL
-import Data.Bytes.Get
-import Data.Bytes.Put (runPutL, runPutS)
-import Data.Bytes.Serial
+import Bitcoin.Transaction (TxHash (getTxHash), hexToTxHash)
+import Bitcoin.Util.Arbitrary (
+    arbitraryBlock,
+    arbitraryBlockHash,
+    arbitraryBlockHeader,
+    arbitraryBlockNode,
+    arbitraryGetBlocks,
+    arbitraryGetHeaders,
+    arbitraryHeaders,
+    arbitraryMerkleBlock,
+    arbitraryNetwork,
+    arbitraryTxHash,
+ )
+import Bitcoin.UtilSpec (
+    JsonBox (..),
+    ReadBox (..),
+    SerialBox (..),
+    testIdentity,
+ )
+import Control.Monad (forM_, unless)
+import Control.Monad.Trans.State.Strict (State, evalState)
 import Data.Either (fromRight)
 import Data.Maybe (fromJust)
 import Data.String (fromString)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Word (Word32)
-import Test.HUnit hiding (State)
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
+import Test.HUnit (Assertion, assertBool, assertEqual)
+import Test.Hspec (Spec, SpecWith, describe, it, runIO, shouldBe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (
+    Arbitrary (arbitrary),
+    Property,
+    forAll,
+    listOf1,
+    (==>),
+ )
 import Text.Printf (printf)
 
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,36 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main (main) where
 
+import qualified Bitcoin.Address.Bech32Spec as Bech32
+import qualified Bitcoin.AddressSpec as Address
+import qualified Bitcoin.BlockSpec as Block
+import qualified Bitcoin.Crypto.HashSpec as Hash
+import qualified Bitcoin.Crypto.SignatureSpec as Sig
+import qualified Bitcoin.Keys.ExtendedSpec as Extended
+import qualified Bitcoin.Keys.MnemonicSpec as Mnemonic
+import qualified Bitcoin.KeysSpec as Keys
+import qualified Bitcoin.NetworkSpec as Net
+import qualified Bitcoin.ScriptSpec as Script
+import qualified Bitcoin.Transaction.PartialSpec as Partial
+import qualified Bitcoin.Transaction.TaprootSpec as Taproot
+import qualified Bitcoin.TransactionSpec as Transaction
+import qualified Bitcoin.UtilSpec as Utils
+import Test.Hspec (hspec)
+
+
+main :: IO ()
+main = hspec $ do
+    Address.spec
+    Bech32.spec
+    Block.spec
+    Hash.spec
+    Sig.spec
+    Keys.spec
+    Extended.spec
+    Mnemonic.spec
+    Net.spec
+    Script.spec
+    Transaction.spec
+    Partial.spec
+    Taproot.spec
+    Utils.spec
+    pure ()


### PR DESCRIPTION
This PR removes the dependencies on `bytes` and `cereal`.  Microbenchmarks show that `binary` is a little faster for encoding and decoding than `cereal`.  Moreover, serializing to lazy `ByteString` is more composable.

Closes #2 
Closes #20 