### PR TITLE
change secp256k1-haskell to libsecp256k1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,10 +98,9 @@ jobs:
           pacman --noconfirm -S mingw-w64-x86_64-autotools
           cmake -S . -B build -G "Unix Makefiles" \
             -DCMAKE_TOOLCHAIN_FILE=../cmake/x86_64-w64-mingw32.toolchain.cmake \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
             -DCMAKE_INSTALL_PREFIX=/mingw64 \
-            -DENABLE_MODULE_SCHNORRSIG=ON \
-            -DENABLE_MODULE_RECOVERY=ON
+            -DSECP256K1_ENABLE_MODULE_RECOVERY=ON
           cmake --build build --target all
           cmake --build build --target test
           cmake --build build --target install

--- a/.github/workflows/fourmolu.yaml
+++ b/.github/workflows/fourmolu.yaml
@@ -37,4 +37,4 @@ jobs:
       - uses: haskell-actions/run-fourmolu@5a9f41fa092841e52e6c57dde5600e586fa766a4
         name: Run fourmolu
         with:
-          version: "0.8.2.0"
+          version: "0.14.0.0"

--- a/bitcoin-bench/Main.hs
+++ b/bitcoin-bench/Main.hs
@@ -74,6 +74,6 @@ roundTrip _ label xHex =
     Just !xBytes = decodeHex $ Text.filter (/= '\n') xHex
     Right !x = binDecode xBytes
 
-    binDecode :: Binary a => ByteString -> Either String a
+    binDecode :: (Binary a) => ByteString -> Either String a
     binDecode = bimap pr3 pr3 . Bin.decodeOrFail . BSL.fromStrict
     pr3 (_, _, z) = z

--- a/bitcoin-test/bitcoin-test.cabal
+++ b/bitcoin-test/bitcoin-test.cabal
@@ -78,9 +78,9 @@ library
     , bytestring >=0.10.10.0
     , containers >=0.6.2.1
     , hspec >=2.7.1
+    , libsecp256k1 >=0.2.0
     , memory >=0.15.0
     , scientific >=0.3.6.2
-    , secp256k1-haskell >=0.4.0
     , string-conversions >=0.4.0.1
     , text >=1.2.3.0
     , time >=1.9.3
@@ -107,9 +107,9 @@ test-suite spec
     , bytestring >=0.10.10.0
     , containers >=0.6.2.1
     , hspec >=2.7.1
+    , libsecp256k1 >=0.2.0
     , memory >=0.15.0
     , scientific >=0.3.6.2
-    , secp256k1-haskell >=0.4.0
     , string-conversions >=0.4.0.1
     , text >=1.2.3.0
     , time >=1.9.3

--- a/bitcoin-test/lib/Bitcoin/BlockSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/BlockSpec.hs
@@ -114,7 +114,7 @@ withChain :: Network -> State HeaderMemory a -> a
 withChain net f = evalState f (initialChain net)
 
 
-chain :: BlockHeaders m => Network -> BlockHeader -> Int -> m ()
+chain :: (BlockHeaders m) => Network -> BlockHeader -> Int -> m ()
 chain net bh i = do
     bnsE <- connectBlocks net myTime bhs
     either error (const $ return ()) bnsE

--- a/bitcoin-test/lib/Bitcoin/Keys/ExtendedSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/Keys/ExtendedSpec.hs
@@ -17,8 +17,8 @@ import Bitcoin.Keys (
     derivePath,
     derivePubPath,
     deriveXPubKey,
-    exportPubKey,
-    getSecKey,
+    exportPubKeyXY,
+    exportSecKey,
     getXPrvKey,
     getXPubKey,
     hardSubKey,
@@ -451,10 +451,10 @@ runVector m v = do
     assertBool "bip44Addr" $
         addrToText btc (xPubAddr $ deriveXPubKey $ derivePath bip44Addr m)
             == Just (v !! 3)
-    assertBool "prvKey" $ encodeHex (getSecKey $ xPrvKey m) == v !! 4
+    assertBool "prvKey" $ encodeHex (exportSecKey $ xPrvKey m) == v !! 4
     assertBool "xPrvWIF" $ xPrvWif btc m == v !! 5
     assertBool "pubKey" $
-        encodeHex (exportPubKey True $ xPubKey $ deriveXPubKey m) == v !! 6
+        encodeHex (exportPubKeyXY True $ xPubKey $ deriveXPubKey m) == v !! 6
     assertBool "chain code" $ encodeHex (U.encodeS $ xPrvChain m) == v !! 7
     assertBool "Hex PubKey" $
         (encodeHex . BSL.toStrict . runPut . putXPubKey btc) (deriveXPubKey m) == v !! 8

--- a/bitcoin-test/lib/Bitcoin/Keys/MnemonicSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/Keys/MnemonicSpec.hs
@@ -306,7 +306,7 @@ invalidMss =
     ]
 
 
-binWordsToBS :: Binary a => [a] -> BSL.ByteString
+binWordsToBS :: (Binary a) => [a] -> BSL.ByteString
 binWordsToBS = foldr f BSL.empty
   where
     f b a = a `BSL.append` Bin.encode b

--- a/bitcoin-test/lib/Bitcoin/ScriptSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/ScriptSpec.hs
@@ -366,8 +366,8 @@ sigHashSpec net = do
 
 testSigHashOne :: Network -> Tx -> Script -> Word64 -> Bool -> Property
 testSigHashOne net tx s val acp =
-    not (null $ txIn tx)
-        ==> if length (txIn tx) > length (txOut tx)
+    not (null $ txIn tx) ==>
+        if length (txIn tx) > length (txOut tx)
             then res `shouldBe` one
             else res `shouldNotBe` one
   where

--- a/bitcoin-test/lib/Bitcoin/ScriptSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/ScriptSpec.hs
@@ -4,7 +4,7 @@ module Bitcoin.ScriptSpec (spec) where
 
 import Bitcoin.Address (addrToText, payToScriptAddress)
 import Bitcoin.Constants (Network (getNetworkName), btc)
-import Bitcoin.Keys (derivePubKeyI, secKey, wrapSecKey)
+import Bitcoin.Keys (derivePubKeyI, importSecKey, wrapSecKey)
 import Bitcoin.Orphans ()
 import Bitcoin.Script (
     Script (Script),
@@ -179,7 +179,7 @@ standardSpec net = do
                 derivePubKeyI $
                     wrapSecKey True $
                         fromJust $
-                            secKey $
+                            importSecKey $
                                 BS.replicate 32 1
         decodeInput net (Script [OP_0, opPushData $ U.encodeS pk])
             `shouldBe` Right (RegularInput (SpendPKHash TxSignatureEmpty pk))
@@ -222,12 +222,9 @@ scriptSpec net =
 
                 unless ("DISABLED" `isInfixOf` flags) $ do
                     let _strict =
-                            "DERSIG"
-                                `isInfixOf` flags
-                                || "STRICTENC"
-                                `isInfixOf` flags
-                                || "NULLDUMMY"
-                                `isInfixOf` flags
+                            "DERSIG" `isInfixOf` flags
+                                || "STRICTENC" `isInfixOf` flags
+                                || "NULLDUMMY" `isInfixOf` flags
                         scriptSig = parseScript siStr
                         scriptPubKey = parseScript soStr
                         decodedOutput = decodeOutputBS scriptPubKey
@@ -369,8 +366,8 @@ sigHashSpec net = do
 
 testSigHashOne :: Network -> Tx -> Script -> Word64 -> Bool -> Property
 testSigHashOne net tx s val acp =
-    not (null $ txIn tx) ==>
-        if length (txIn tx) > length (txOut tx)
+    not (null $ txIn tx)
+        ==> if length (txIn tx) > length (txOut tx)
             then res `shouldBe` one
             else res `shouldNotBe` one
   where

--- a/bitcoin-test/lib/Bitcoin/Util/Arbitrary/Keys.hs
+++ b/bitcoin-test/lib/Bitcoin/Util/Arbitrary/Keys.hs
@@ -7,6 +7,7 @@ import Bitcoin.Crypto
 import Bitcoin.Keys.Common
 import Bitcoin.Keys.Extended
 import Bitcoin.Keys.Extended.Internal (Fingerprint (..))
+import Bitcoin.Orphans ()
 import Bitcoin.Util.Arbitrary.Crypto
 import Data.Bits (clearBit)
 import Data.Coerce (coerce)
@@ -92,9 +93,10 @@ arbitraryParsedPath =
 -- | Arbitrary message hash, private key, nonce and corresponding signature. The
 -- signature is generated with a random message, random private key and a random
 -- nonce.
-arbitrarySignature :: Gen (Hash256, SecKey, Sig)
+arbitrarySignature :: Gen (Hash256, SecKey, Signature)
 arbitrarySignature = do
     m <- arbitraryHash256
     key <- arbitrary
     let sig = signHash key m
+    sig <- maybe discard pure sig
     return (m, key, sig)

--- a/bitcoin-test/lib/Bitcoin/Util/Arbitrary/Util.hs
+++ b/bitcoin-test/lib/Bitcoin/Util/Arbitrary/Util.hs
@@ -93,7 +93,7 @@ arbitraryNetwork :: Gen Network
 arbitraryNetwork = elements allNets
 
 
-arbitraryNetData :: Arbitrary a => Gen (Network, a)
+arbitraryNetData :: (Arbitrary a) => Gen (Network, a)
 arbitraryNetData = do
     net <- arbitraryNetwork
     x <- arbitrary

--- a/bitcoin-test/lib/Bitcoin/UtilSpec.hs
+++ b/bitcoin-test/lib/Bitcoin/UtilSpec.hs
@@ -114,7 +114,7 @@ testMaybeToEither m str = maybeToEither str m == Left str
 
 {-- Test Utilities --}
 
-readTestFile :: A.FromJSON a => FilePath -> IO a
+readTestFile :: (A.FromJSON a) => FilePath -> IO a
 readTestFile fp =
     A.eitherDecodeFileStrict ("data/" <> fp) >>= either (error . message) return
   where

--- a/bitcoin-test/package.yaml
+++ b/bitcoin-test/package.yaml
@@ -26,7 +26,7 @@ dependencies:
   - hspec >= 2.7.1
   - memory >= 0.15.0
   - scientific >= 0.3.6.2
-  - secp256k1-haskell >= 0.4.0
+  - libsecp256k1 >= 0.2.0
   - string-conversions >= 0.4.0.1
   - text >= 1.2.3.0
   - time >= 1.9.3

--- a/bitcoin/bitcoin.cabal
+++ b/bitcoin/bitcoin.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           bitcoin
-version:        0.1.0
+version:        0.1.1
 synopsis:       Bitcoin library for Haskell
 description:    Please see the README on GitHub at <https://github.com/haskell-bitcoin/bitcoin#readme>
 category:       Bitcoin, Finance, Network
@@ -73,10 +73,10 @@ library
     , cryptonite >=0.30
     , deepseq >=1.4.4.0
     , hashable >=1.3.0.0
+    , libsecp256k1 >=0.2.0
     , memory >=0.15.0
     , murmur3 >=1.0.3
     , network >=3.1.1.1
-    , secp256k1-haskell >=0.4.0 && <1
     , split >=0.2.3.3
     , string-conversions >=0.4.0.1
     , text >=1.2.3.0

--- a/bitcoin/package.yaml
+++ b/bitcoin/package.yaml
@@ -1,5 +1,5 @@
 name: bitcoin
-version: 0.1.0
+version: 0.1.1
 synopsis: Bitcoin library for Haskell
 description: Please see the README on GitHub at <https://github.com/haskell-bitcoin/bitcoin#readme>
 category: Bitcoin, Finance, Network
@@ -28,7 +28,7 @@ dependencies:
   - murmur3 >= 1.0.3
   - network >= 3.1.1.1
   - split >= 0.2.3.3
-  - secp256k1-haskell >= 0.4.0 && < 1
+  - libsecp256k1 >= 0.2.0
   - string-conversions >= 0.4.0.1
   - text >= 1.2.3.0
   - transformers >= 0.5.6.2

--- a/bitcoin/src/Bitcoin/Address/Bech32.hs
+++ b/bitcoin/src/Bitcoin/Address/Bech32.hs
@@ -76,7 +76,7 @@ type HRP = Text
 type Data = [Word8]
 
 
-(.>>.), (.<<.) :: Bits a => a -> Int -> a
+(.>>.), (.<<.) :: (Bits a) => a -> Int -> a
 (.>>.) = unsafeShiftR
 (.<<.) = unsafeShiftL
 
@@ -94,14 +94,14 @@ instance Ix Word5 where
 
 
 -- | Convert an integer number into a five-bit word.
-word5 :: Integral a => a -> Word5
+word5 :: (Integral a) => a -> Word5
 word5 x = UnsafeWord5 (fromIntegral x .&. 31)
 {-# INLINE word5 #-}
 {-# SPECIALIZE INLINE word5 :: Word8 -> Word5 #-}
 
 
 -- | Convert a five-bit word into a number.
-fromWord5 :: Num a => Word5 -> a
+fromWord5 :: (Num a) => Word5 -> a
 fromWord5 (UnsafeWord5 x) = fromIntegral x
 {-# INLINE fromWord5 #-}
 {-# SPECIALIZE INLINE fromWord5 :: Word5 -> Word8 #-}
@@ -165,9 +165,9 @@ bech32VerifyChecksum :: HRP -> [Word5] -> Maybe Bech32Encoding
 bech32VerifyChecksum hrp dat =
     let poly = bech32Polymod (bech32HRPExpand hrp ++ dat)
      in if
-                | poly == bech32Const Bech32 -> Just Bech32
-                | poly == bech32Const Bech32m -> Just Bech32m
-                | otherwise -> Nothing
+            | poly == bech32Const Bech32 -> Just Bech32
+            | poly == bech32Const Bech32m -> Just Bech32m
+            | otherwise -> Nothing
 
 
 -- | Maximum length of a Bech32 result.
@@ -300,7 +300,7 @@ noPadding frombits bits padValue result = do
 -- \(2^{tobits}\). {frombits} and {twobits} must be positive and
 -- \(2^{frombits}\) and \(2^{tobits}\) must be smaller than the size of Word.
 -- Every value in 'dat' must be strictly smaller than \(2^{frombits}\).
-convertBits :: Functor f => [Word] -> Int -> Int -> Pad f -> f [Word]
+convertBits :: (Functor f) => [Word] -> Int -> Int -> Pad f -> f [Word]
 convertBits dat frombits tobits pad = concat . reverse <$> go dat 0 0 []
   where
     go [] acc bits result =

--- a/bitcoin/src/Bitcoin/Constants.hs
+++ b/bitcoin/src/Bitcoin/Constants.hs
@@ -27,7 +27,7 @@ import Data.String (IsString)
 
 
 -- | Version of Bitcoin package.
-versionString :: IsString a => a
+versionString :: (IsString a) => a
 
 #ifdef CURRENT_PACKAGE_VERSION
 versionString = CURRENT_PACKAGE_VERSION

--- a/bitcoin/src/Bitcoin/Crypto/Hash.hs
+++ b/bitcoin/src/Bitcoin/Crypto/Hash.hs
@@ -172,17 +172,17 @@ instance Binary Hash160 where
 
 
 -- | Use this function to produce hashes during the process of serialization
-hashWithL :: HashAlgorithm alg => alg -> BSL.ByteString -> Digest alg
+hashWithL :: (HashAlgorithm alg) => alg -> BSL.ByteString -> Digest alg
 hashWithL _ = hashFinalize . hashUpdates hashInit . BSL.toChunks
 
 
 -- | Calculate SHA512 hash.
-sha512 :: ByteArrayAccess b => b -> Hash512
+sha512 :: (ByteArrayAccess b) => b -> Hash512
 sha512 = Hash512 . BSS.toShort . BA.convert . hashWith SHA512
 
 
 -- | Calculate SHA256 hash.
-sha256 :: ByteArrayAccess b => b -> Hash256
+sha256 :: (ByteArrayAccess b) => b -> Hash256
 sha256 = Hash256 . BSS.toShort . BA.convert . hashWith SHA256
 
 
@@ -192,17 +192,17 @@ sha256L = Hash256 . BSS.toShort . BA.convert . hashWithL SHA256
 
 
 -- | Calculate RIPEMD160 hash.
-ripemd160 :: ByteArrayAccess b => b -> Hash160
+ripemd160 :: (ByteArrayAccess b) => b -> Hash160
 ripemd160 = Hash160 . BSS.toShort . BA.convert . hashWith RIPEMD160
 
 
 -- | Claculate SHA1 hash.
-sha1 :: ByteArrayAccess b => b -> Hash160
+sha1 :: (ByteArrayAccess b) => b -> Hash160
 sha1 = Hash160 . BSS.toShort . BA.convert . hashWith SHA1
 
 
 -- | Compute two rounds of SHA-256.
-doubleSHA256 :: ByteArrayAccess b => b -> Hash256
+doubleSHA256 :: (ByteArrayAccess b) => b -> Hash256
 doubleSHA256 =
     Hash256 . BSS.toShort . BA.convert . hashWith SHA256 . hashWith SHA256
 
@@ -214,7 +214,7 @@ doubleSHA256L =
 
 
 -- | Compute SHA-256 followed by RIPMED-160.
-addressHash :: ByteArrayAccess b => b -> Hash160
+addressHash :: (ByteArrayAccess b) => b -> Hash160
 addressHash =
     Hash160 . BSS.toShort . BA.convert . hashWith RIPEMD160 . hashWith SHA256
 

--- a/bitcoin/src/Bitcoin/Crypto/Signature.hs
+++ b/bitcoin/src/Bitcoin/Crypto/Signature.hs
@@ -14,55 +14,35 @@ module Bitcoin.Crypto.Signature (
     verifyHashSig,
     isCanonicalHalfOrder,
     decodeStrictSig,
-    exportSig,
 ) where
 
-import Bitcoin.Crypto.Hash (Hash256)
+import Bitcoin.Crypto.Hash (Hash256 (getHash256))
 import qualified Bitcoin.Util as U
 import Control.Monad (guard, unless, when)
-import Crypto.Secp256k1 (
-    CompactSig (getCompactSig),
-    Msg,
-    PubKey,
-    SecKey,
-    Sig,
-    exportCompactSig,
-    exportSig,
-    importSig,
-    msg,
-    normalizeSig,
-    signMsg,
-    verifySig,
- )
+import Crypto.Secp256k1 (PubKeyXY, SecKey, Signature, ecdsaNormalizeSignature, ecdsaSign, ecdsaVerify, exportSignatureCompact, exportSignatureDer, importSignatureDer)
 import Data.Binary.Get (Get, getByteString, getWord8, lookAhead)
 import Data.Binary.Put (Put, putByteString)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.ByteString.Short (fromShort)
 import Data.Maybe (fromMaybe, isNothing)
 import Numeric (showHex)
 
 
--- | Convert 256-bit hash into a 'Msg' for signing or verification.
-hashToMsg :: Hash256 -> Msg
-hashToMsg = fromMaybe e . msg . U.encodeS
-  where
-    e = error "Could not convert 32-byte hash to secp256k1 message"
-
-
 -- | Sign a 256-bit hash using secp256k1 elliptic curve.
-signHash :: SecKey -> Hash256 -> Sig
-signHash k = signMsg k . hashToMsg
+signHash :: SecKey -> Hash256 -> Maybe Signature
+signHash k = ecdsaSign k . fromShort . getHash256
 
 
 -- | Verify an ECDSA signature for a 256-bit hash.
-verifyHashSig :: Hash256 -> Sig -> PubKey -> Bool
-verifyHashSig h s p = verifySig p norm (hashToMsg h)
+verifyHashSig :: Hash256 -> Signature -> PubKeyXY -> Bool
+verifyHashSig h s p = ecdsaVerify (fromShort $ getHash256 h) p norm
   where
-    norm = fromMaybe s (normalizeSig s)
+    norm = ecdsaNormalizeSignature s
 
 
 -- | Deserialize an ECDSA signature as commonly encoded in Bitcoin.
-getSig :: Get Sig
+getSig :: Get Signature
 getSig = do
     l <-
         lookAhead $ do
@@ -82,24 +62,24 @@ getSig = do
 
 
 -- | Serialize an ECDSA signature for Bitcoin use.
-putSig :: Sig -> Put
-putSig s = putByteString $ exportSig s
+putSig :: Signature -> Put
+putSig s = putByteString $ exportSignatureDer s
 
 
 -- | Is canonical half order.
-isCanonicalHalfOrder :: Sig -> Bool
-isCanonicalHalfOrder = isNothing . normalizeSig
+isCanonicalHalfOrder :: Signature -> Bool
+isCanonicalHalfOrder = ecdsaNormalizeSignature >>= (==)
 
 
 -- | Decode signature strictly.
-decodeStrictSig :: ByteString -> Maybe Sig
+decodeStrictSig :: ByteString -> Maybe Signature
 decodeStrictSig bs = do
-    g <- importSig bs
+    g <- importSignatureDer bs
     -- <http://www.secg.org/sec1-v2.pdf Section 4.1.4>
     -- 4.1.4.1 (r and s can not be zero)
-    let compact = exportCompactSig g
+    let compact = exportSignatureCompact g
     let zero = BS.replicate 32 0
-    guard $ BS.take 32 (getCompactSig compact) /= zero
-    guard $ BS.take 32 (BS.drop 32 (getCompactSig compact)) /= zero
+    guard $ BS.take 32 compact /= zero
+    guard $ BS.take 32 (BS.drop 32 compact) /= zero
     guard $ isCanonicalHalfOrder g
     return g

--- a/bitcoin/src/Bitcoin/Keys/Common.hs
+++ b/bitcoin/src/Bitcoin/Keys/Common.hs
@@ -15,16 +15,16 @@ module Bitcoin.Keys.Common (
     -- * Public & Private Keys
     PubKeyI (..),
     SecKeyI (..),
-    exportPubKey,
-    importPubKey,
+    exportPubKeyXY,
+    importPubKeyXY,
     wrapPubKey,
     derivePubKeyI,
     wrapSecKey,
     fromMiniKey,
     tweakPubKey,
     tweakSecKey,
-    getSecKey,
-    secKey,
+    exportSecKey,
+    importSecKey,
 
     -- ** Private Key Wallet Import Format (WIF)
     fromWif,
@@ -44,17 +44,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad (guard, mzero, (<=<))
 import Crypto.Hash (hashWith)
 import Crypto.Hash.Algorithms (SHA256 (SHA256))
-import Crypto.Secp256k1 (
-    PubKey,
-    SecKey (..),
-    derivePubKey,
-    exportPubKey,
-    importPubKey,
-    secKey,
-    tweak,
-    tweakAddPubKey,
-    tweakAddSecKey,
- )
+import Crypto.Secp256k1 (PubKeyXY, SecKey, derivePubKey, exportPubKeyXY, exportSecKey, importPubKeyXY, importSecKey, importTweak, pubKeyTweakAdd, secKeyTweakAdd)
 import Data.Binary (Binary (..))
 import Data.Binary.Get (getByteString, getWord8, lookAhead)
 import Data.Binary.Put (putByteString)
@@ -71,7 +61,7 @@ import GHC.Generics (Generic)
 
 -- | Elliptic curve public key type with expected serialized compression flag.
 data PubKeyI = PubKeyI
-    { pubKeyPoint :: !PubKey
+    { pubKeyPoint :: !PubKeyXY
     , pubKeyCompressed :: !Bool
     }
     deriving (Generic, Eq, Show, Read, Hashable, NFData)
@@ -100,18 +90,18 @@ instance Binary PubKeyI where
         c = do
             bs <- getByteString 33
             maybe (fail "Could not decode public key") return $
-                PubKeyI <$> importPubKey bs <*> pure True
+                PubKeyI <$> importPubKeyXY bs <*> pure True
         u = do
             bs <- getByteString 65
             maybe (fail "Could not decode public key") return $
-                PubKeyI <$> importPubKey bs <*> pure False
+                PubKeyI <$> importPubKeyXY bs <*> pure False
 
 
-    put pk = putByteString $ (exportPubKey <$> pubKeyCompressed <*> pubKeyPoint) pk
+    put pk = putByteString $ (exportPubKeyXY <$> pubKeyCompressed <*> pubKeyPoint) pk
 
 
 -- | Wrap a public key from secp256k1 library adding information about compression.
-wrapPubKey :: Bool -> PubKey -> PubKeyI
+wrapPubKey :: Bool -> PubKeyXY -> PubKeyI
 wrapPubKey c p = PubKeyI p c
 
 
@@ -122,8 +112,8 @@ derivePubKeyI (SecKeyI d c) = PubKeyI (derivePubKey d) c
 
 
 -- | Tweak a public key.
-tweakPubKey :: PubKey -> Hash256 -> Maybe PubKey
-tweakPubKey p = tweakAddPubKey p <=< tweak . U.encodeS
+tweakPubKey :: PubKeyXY -> Hash256 -> Maybe PubKeyXY
+tweakPubKey p = pubKeyTweakAdd p <=< importTweak . U.encodeS
 
 
 -- | Elliptic curve private key type with expected public key compression
@@ -144,14 +134,14 @@ wrapSecKey c d = SecKeyI d c
 
 -- | Tweak a private key.
 tweakSecKey :: SecKey -> Hash256 -> Maybe SecKey
-tweakSecKey key = tweakAddSecKey key <=< tweak . U.encodeS
+tweakSecKey key = secKeyTweakAdd key <=< importTweak . U.encodeS
 
 
 -- | Decode Casascius mini private keys (22 or 30 characters).
 fromMiniKey :: ByteString -> Maybe SecKeyI
 fromMiniKey bs = do
     guard checkShortKey
-    wrapSecKey False <$> (secKey . BA.convert . hashWith SHA256) bs
+    wrapSecKey False <$> (importSecKey . BA.convert . hashWith SHA256) bs
   where
     checkHash = BA.convert . hashWith SHA256 $ bs `BS.append` "?"
     checkShortKey = BS.length bs `elem` [22, 30] && BS.head checkHash == 0x00
@@ -165,11 +155,11 @@ fromWif net wif = do
     guard (BSL.head bs == getSecretPrefix net)
     case BSL.length bs of
         -- Uncompressed format
-        33 -> wrapSecKey False <$> (secKey . BSL.toStrict) (BSL.tail bs)
+        33 -> wrapSecKey False <$> (importSecKey . BSL.toStrict) (BSL.tail bs)
         -- Compressed format
         34 -> do
             guard $ BSL.last bs == 0x01
-            wrapSecKey True <$> (secKey . BS.tail . BS.init . BSL.toStrict) bs
+            wrapSecKey True <$> (importSecKey . BS.tail . BS.init . BSL.toStrict) bs
         -- Bad length
         _ -> Nothing
 
@@ -179,5 +169,5 @@ toWif :: Network -> SecKeyI -> Base58
 toWif net (SecKeyI k c) =
     encodeBase58Check . BSL.cons (getSecretPrefix net) . BSL.fromStrict $
         if c
-            then getSecKey k `BS.snoc` 0x01
-            else getSecKey k
+            then exportSecKey k `BS.snoc` 0x01
+            else exportSecKey k

--- a/bitcoin/src/Bitcoin/Network/Common.hs
+++ b/bitcoin/src/Bitcoin/Network/Common.hs
@@ -415,7 +415,7 @@ instance Binary VarInt where
             Put.putWord64le x
 
 
-putVarInt :: Integral a => a -> Put
+putVarInt :: (Integral a) => a -> Put
 putVarInt = put . VarInt . fromIntegral
 
 

--- a/bitcoin/src/Bitcoin/Script/SigHash.hs
+++ b/bitcoin/src/Bitcoin/Script/SigHash.hs
@@ -30,7 +30,7 @@ module Bitcoin.Script.SigHash (
 
 import Bitcoin.Crypto (
     Hash256,
-    Sig,
+    Signature,
     decodeStrictSig,
     putSig,
  )
@@ -293,7 +293,7 @@ txSigHashSegwitV0 _ tx out v i sh =
 -- transaction inputs are of type 'TxSignature'.
 data TxSignature
     = TxSignature
-        { txSignature :: !Sig
+        { txSignature :: !Signature
         , txSignatureSigHash :: !SigHash
         }
     | TxSignatureEmpty

--- a/bitcoin/src/Bitcoin/Script/Standard.hs
+++ b/bitcoin/src/Bitcoin/Script/Standard.hs
@@ -269,7 +269,7 @@ encodeOutput s = Script $ case s of
     (DataCarrier d) -> [OP_RETURN, opPushData d]
 
 
-pushItem :: Binary a => a -> ScriptOp
+pushItem :: (Binary a) => a -> ScriptOp
 pushItem = opPushData . U.encodeS
 
 

--- a/bitcoin/src/Bitcoin/Transaction/Builder.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Builder.hs
@@ -83,7 +83,7 @@ import qualified Bitcoin.Util as U
 import Control.Applicative ((<|>))
 import Control.Arrow (first)
 import Control.Monad (foldM, unless)
-import Crypto.Secp256k1 (PubKey, SecKey)
+import Crypto.Secp256k1 (PubKeyXY, SecKey)
 import qualified Data.Binary as Bin
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -343,7 +343,7 @@ countMulSig ::
     Script ->
     Word64 ->
     Int ->
-    [PubKey] ->
+    [PubKeyXY] ->
     [TxSignature] ->
     Int
 countMulSig net tx out val i =
@@ -352,7 +352,7 @@ countMulSig net tx out val i =
     h = txSigHash net tx out val i
 
 
-countMulSig' :: (SigHash -> Hash256) -> [PubKey] -> [TxSignature] -> Int
+countMulSig' :: (SigHash -> Hash256) -> [PubKeyXY] -> [TxSignature] -> Int
 countMulSig' _ [] _ = 0
 countMulSig' _ _ [] = 0
 countMulSig' h (_ : pubs) (TxSignatureEmpty : sigs) = countMulSig' h pubs sigs

--- a/bitcoin/src/Bitcoin/Transaction/Builder/Sign.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Builder/Sign.hs
@@ -131,7 +131,10 @@ signInput ::
     SecKeyI ->
     Either String Tx
 signInput net tx i (sigIn@(SigInput so val _ _ rdmM), nest) key = do
-    let sig = makeSignature net tx i sigIn key
+    let mSig = makeSignature net tx i sigIn key
+    sig <- case mSig of
+        Nothing -> Left "Signature generation failed"
+        Just x -> pure x
     si <- buildInput net tx i so val rdmM sig $ derivePubKeyI key
     w <- updatedWitnessData tx i so si
     return
@@ -269,9 +272,9 @@ parseExistingSigs net tx so i = insSigs <> witSigs
 
 
 -- | Produce a structured representation of a deterministic (RFC-6979) signature over an input.
-makeSignature :: Network -> Tx -> Int -> SigInput -> SecKeyI -> TxSignature
+makeSignature :: Network -> Tx -> Int -> SigInput -> SecKeyI -> Maybe TxSignature
 makeSignature net tx i (SigInput so val _ sh rdmM) key =
-    TxSignature (signHash (secKeyData key) m) sh
+    flip TxSignature sh <$> signHash (secKeyData key) m
   where
     m = makeSigHash net tx i so val sh rdmM
 

--- a/bitcoin/src/Bitcoin/Transaction/Genesis.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Genesis.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
---Module      : Bitcoin.Transaction.Genesis
---Copyright   : No rights reserved
---License     : UNLICENSE
---Maintainer  : jprupp@protonmail.ch
---Stability   : experimental
---Portability : POSIX
+-- Module      : Bitcoin.Transaction.Genesis
+-- Copyright   : No rights reserved
+-- License     : UNLICENSE
+-- Maintainer  : jprupp@protonmail.ch
+-- Stability   : experimental
+-- Portability : POSIX
 --
---Code related to transactions parsing and serialization.
+-- Code related to transactions parsing and serialization.
 module Bitcoin.Transaction.Genesis (
     genesisTx,
 ) where

--- a/bitcoin/src/Bitcoin/Transaction/Partial.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Partial.hs
@@ -360,7 +360,7 @@ onPrevTxOut net signer tx ix input prevTxData =
   where
     newSigs = HM.mapWithKey sigForInput sigKeys
     sigForInput thePubKey theSecKey =
-        encodeTxSig . makeSignature net tx ix theSigInput $
+        maybe (error "Signature Gen Failed") encodeTxSig . makeSignature net tx ix theSigInput $
             SecKeyI theSecKey (pubKeyCompressed thePubKey)
 
     theSigInput =
@@ -771,13 +771,13 @@ getSizedBytes getItem = do
     isolate n getItem
 
 
-putKeyValue :: Enum t => t -> Put -> Put
+putKeyValue :: (Enum t) => t -> Put -> Put
 putKeyValue t v = do
     putKey t
     putSizedBytes v
 
 
-putKey :: Enum t => t -> Put
+putKey :: (Enum t) => t -> Put
 putKey t = do
     putVarInt (1 :: Word8)
     putWord8 (enumWord8 t)
@@ -904,7 +904,7 @@ getHDPath keySize =
         <*> (unPSBTHDPath <$> get)
 
 
-putHDPath :: Enum t => t -> HashMap PubKeyI (Fingerprint, [KeyIndex]) -> Put
+putHDPath :: (Enum t) => t -> HashMap PubKeyI (Fingerprint, [KeyIndex]) -> Put
 putHDPath t = putPubKeyMap put t . fmap PSBTHDPath
 
 
@@ -935,7 +935,7 @@ instance Binary PSBTHDPath where
         bs = runPut $ put fp >> mapM_ putWord32le kis
 
 
-putPubKeyMap :: Enum t => (a -> Put) -> t -> HashMap PubKeyI a -> Put
+putPubKeyMap :: (Enum t) => (a -> Put) -> t -> HashMap PubKeyI a -> Put
 putPubKeyMap f t =
     void . HashMap.traverseWithKey putItem
   where
@@ -944,7 +944,7 @@ putPubKeyMap f t =
         f v
 
 
-enumWord8 :: Enum a => a -> Word8
+enumWord8 :: (Enum a) => a -> Word8
 enumWord8 = fromIntegral . fromEnum
 
 
@@ -953,7 +953,7 @@ word8Enum n | n <= enumWord8 (maxBound :: a) = Right . toEnum $ fromIntegral n
 word8Enum n = Left n
 
 
-whenJust :: Monad m => (a -> m ()) -> Maybe a -> m ()
+whenJust :: (Monad m) => (a -> m ()) -> Maybe a -> m ()
 whenJust = maybe (return ())
 
 

--- a/bitcoin/src/Bitcoin/Transaction/Taproot.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Taproot.hs
@@ -10,7 +10,6 @@
 -- This module provides support for reperesenting full taproot outputs and parsing
 -- taproot witnesses.  For reference see BIPS 340, 341, and 342.
 module Bitcoin.Transaction.Taproot (
-    XOnlyPubKey (..),
     TapLeafVersion,
     MAST (..),
     mastCommitment,
@@ -25,7 +24,7 @@ module Bitcoin.Transaction.Taproot (
     verifyScriptPathData,
 ) where
 
-import Bitcoin.Crypto (PubKey, initTaggedHash, tweak, tweakAddPubKey)
+import Bitcoin.Crypto (PubKeyXO, PubKeyXY, exportPubKeyXO, importTweak, initTaggedHash, pubKeyTweakAdd, pubKeyXOTweakAdd, xyToXO)
 import Bitcoin.Keys.Common (PubKeyI (PubKeyI), pubKeyPoint)
 import Bitcoin.Network.Common (VarInt (VarInt))
 import Bitcoin.Script.Common (Script)
@@ -42,6 +41,7 @@ import Crypto.Hash (
     hashUpdate,
     hashUpdates,
  )
+import Crypto.Secp256k1 (exportPubKeyXY, importPubKeyXO, importPubKeyXY)
 import Data.Binary (Binary (..))
 import qualified Data.Binary as Bin
 import Data.Binary.Get (getByteString, getLazyByteString, getWord8)
@@ -58,36 +58,12 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Word (Word8)
 
 
--- | An x-only pubkey corresponds to the keys @(x,y)@ and @(x, -y)@.  The
---equality test only checks the x-coordinate.  An x-only pubkey serializes to 32
---bytes.
-newtype XOnlyPubKey = XOnlyPubKey {xOnlyPubKey :: PubKey}
-    deriving (Show)
-
-
-instance Eq XOnlyPubKey where
-    (==) = (==) `on` Bin.encode
-
-
-instance Binary XOnlyPubKey where
-    put (XOnlyPubKey pk) =
-        putLazyByteString
-            . BSL.drop 1
-            . Bin.encode
-            $ PubKeyI pk True
-    get =
-        either fail (pure . XOnlyPubKey . pubKeyPoint)
-            . U.decode
-            . BSL.cons 0x02
-            =<< getLazyByteString 32
-
-
 type TapLeafVersion = Word8
 
 
 -- | Merklized Abstract Syntax Tree.  This type can represent trees where only a
---subset of the leaves are known.  Note that the tree is invariant under swapping
---branches at an internal node.
+-- subset of the leaves are known.  Note that the tree is invariant under swapping
+-- branches at an internal node.
 data MAST
     = MASTBranch MAST MAST
     | MASTLeaf TapLeafVersion Script
@@ -96,7 +72,7 @@ data MAST
 
 
 -- | Get the inclusion proofs for the leaves in the tree.  The proof is ordered
---leaf-to-root.
+-- leaf-to-root.
 getMerkleProofs :: MAST -> [(TapLeafVersion, Script, [Digest SHA256])]
 getMerkleProofs = getProofs mempty
   where
@@ -145,21 +121,21 @@ leafHash leafVersion leafScript =
 
 -- | Representation of a full taproot output.
 data TaprootOutput = TaprootOutput
-    { taprootInternalKey :: PubKey
+    { taprootInternalKey :: PubKeyXO
     , taprootMAST :: Maybe MAST
     }
     deriving (Show)
 
 
-taprootOutputKey :: TaprootOutput -> PubKey
+taprootOutputKey :: TaprootOutput -> PubKeyXY
 taprootOutputKey TaprootOutput{taprootInternalKey, taprootMAST} =
-    fromMaybe keyFail $ tweak commitment >>= tweakAddPubKey taprootInternalKey
+    fromMaybe keyFail $ importTweak commitment >>= pubKeyXOTweakAdd taprootInternalKey
   where
     commitment = taprootCommitment taprootInternalKey $ mastCommitment <$> taprootMAST
     keyFail = error "bitcoin taprootOutputKey: key derivation failed"
 
 
-taprootCommitment :: PubKey -> Maybe (Digest SHA256) -> ByteString
+taprootCommitment :: PubKeyXO -> Maybe (Digest SHA256) -> ByteString
 taprootCommitment internalKey merkleRoot =
     BA.convert
         . hashFinalize
@@ -167,12 +143,12 @@ taprootCommitment internalKey merkleRoot =
         . (`hashUpdates` BSL.toChunks keyBytes)
         $ initTaggedHash "TapTweak"
   where
-    keyBytes = Bin.encode $ XOnlyPubKey internalKey
+    keyBytes = BSL.fromStrict $ exportPubKeyXO $ internalKey
 
 
 -- | Generate the output script for a taproot output
 taprootScriptOutput :: TaprootOutput -> ScriptOutput
-taprootScriptOutput = PayWitness 0x01 . U.encodeS . XOnlyPubKey . taprootOutputKey
+taprootScriptOutput = PayWitness 0x01 . exportPubKeyXO . fst . xyToXO . taprootOutputKey
 
 
 -- | Comprehension of taproot witness data
@@ -190,7 +166,7 @@ data ScriptPathData = ScriptPathData
     , scriptPathExternalIsOdd :: Bool
     , scriptPathLeafVersion :: Word8
     -- ^ This value is masked by 0xFE
-    , scriptPathInternalKey :: PubKey
+    , scriptPathInternalKey :: PubKeyXO
     , scriptPathControl :: [ByteString]
     }
     deriving (Eq, Show)
@@ -223,7 +199,10 @@ viewTaprootWitness witnessStack = case reverse witnessStack of
     deconstructControl = eitherToMaybe . U.runGet deserializeControl . BSL.fromStrict
     deserializeControl = do
         v <- getWord8
-        k <- xOnlyPubKey <$> get
+        keyBytes <- getByteString 32
+        k <- case importPubKeyXO keyBytes of
+            Nothing -> fail "Invalid PubKeyXO"
+            Just x -> pure x
         proof <- many $ getByteString 32
         pure (v, k, proof)
 
@@ -237,7 +216,7 @@ encodeTaprootWitness = \case
             <> [ U.encodeS $ scriptPathScript scriptPathData
                , mconcat
                     [ BS.pack [scriptPathLeafVersion scriptPathData .|. parity scriptPathData]
-                    , U.encodeS . XOnlyPubKey $ scriptPathInternalKey scriptPathData
+                    , exportPubKeyXO $ scriptPathInternalKey scriptPathData
                     , mconcat $ scriptPathControl scriptPathData
                     ]
                , fromMaybe mempty $ scriptPathAnnex scriptPathData
@@ -249,25 +228,27 @@ encodeTaprootWitness = \case
 -- | Verify that the script path spend is valid, except for script execution.
 verifyScriptPathData ::
     -- | Output key
-    PubKey ->
+    PubKeyXY ->
     ScriptPathData ->
     Bool
 verifyScriptPathData outputKey scriptPathData = fromMaybe False $ do
-    tweak commitment >>= fmap onComputedKey . tweakAddPubKey (scriptPathInternalKey scriptPathData)
+    tweak <- importTweak commitment
+    tweaked <- pubKeyXOTweakAdd (scriptPathInternalKey scriptPathData) tweak
+    pure $ uncurry onComputedKey . xyToXO $ tweaked
   where
-    onComputedKey computedKey =
-        XOnlyPubKey outputKey == XOnlyPubKey computedKey
-            && expectedParity == keyParity computedKey
+    onComputedKey computedKey computedParity =
+        fst (xyToXO outputKey) == computedKey
+            && expectedParity == computedParity
     commitment = taprootCommitment (scriptPathInternalKey scriptPathData) (Just merkleRoot)
     merkleRoot =
         foldl' hashBranch theLeafHash
             . mapMaybe (digestFromByteString @SHA256)
             $ scriptPathControl scriptPathData
     theLeafHash = (leafHash <$> (.&. 0xFE) . scriptPathLeafVersion <*> scriptPathScript) scriptPathData
-    expectedParity = bool 0 1 $ scriptPathExternalIsOdd scriptPathData
+    expectedParity = bool False True $ scriptPathExternalIsOdd scriptPathData
 
 
-keyParity :: PubKey -> Word8
+keyParity :: PubKeyXY -> Word8
 keyParity key = case BSL.unpack . Bin.encode $ PubKeyI key True of
     0x02 : _ -> 0x00
     _ -> 0x01

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
 resolver: lts-22.6
-system-ghc: true
+system-ghc: false
 nix:
   packages:
     - secp256k1
     - pkg-config
 extra-deps:
-  - fourmolu-0.8.2.0
+  - fourmolu-0.14.0.0
   - cryptonite-0.30
   - libsecp256k1-0.2.0
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ nix:
 extra-deps:
   - fourmolu-0.8.2.0
   - cryptonite-0.30
-  - secp256k1-haskell-0.7.0
+  - libsecp256k1-0.2.0
 packages:
   - ./bitcoin
   - ./bitcoin-test

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,9 +5,11 @@ nix:
     - secp256k1
     - pkg-config
 extra-deps:
-  - fourmolu-0.14.0.0
   - cryptonite-0.30
   - libsecp256k1-0.2.0
+  # for fourmolu CI
+  - fourmolu-0.14.0.0
+  - ghc-lib-parser-9.6.2.20230523
 packages:
   - ./bitcoin
   - ./bitcoin-test

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ nix:
     - pkg-config
 extra-deps:
   - cryptonite-0.30
-  - libsecp256k1-0.2.0
+  - libsecp256k1-0.2.1
   # for fourmolu CI
   - fourmolu-0.14.0.0
   - ghc-lib-parser-9.6.2.20230523

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,6 @@ resolver: lts-22.6
 system-ghc: false
 nix:
   packages:
-    - secp256k1
     - pkg-config
 extra-deps:
   - cryptonite-0.30

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: fourmolu-0.14.0.0@sha256:ba97d135f44cd5fb670dd47228ec3c65d3a886cc293a548510671c78c512c240,6755
-    pantry-tree:
-      sha256: e70f2d81866ac2cb200e8ebc5372186d5bb293e253b4e51fadba2309bb40ed85
-      size: 156343
-  original:
-    hackage: fourmolu-0.14.0.0
-- completed:
     hackage: cryptonite-0.30@sha256:12c85dea7be63e5ad90bcb487eb3846bf3c413347f94336fa1dede7b28f9936a,18301
     pantry-tree:
       sha256: df1cbe4cc40d569cc75ffed40bc5deac43cb085653980b42b9b6a5d4b745a30a
@@ -25,6 +18,20 @@ packages:
       size: 902
   original:
     hackage: libsecp256k1-0.2.0
+- completed:
+    hackage: fourmolu-0.14.0.0@sha256:ba97d135f44cd5fb670dd47228ec3c65d3a886cc293a548510671c78c512c240,6755
+    pantry-tree:
+      sha256: e70f2d81866ac2cb200e8ebc5372186d5bb293e253b4e51fadba2309bb40ed85
+      size: 156343
+  original:
+    hackage: fourmolu-0.14.0.0
+- completed:
+    hackage: ghc-lib-parser-9.6.2.20230523@sha256:160fc11671ce69e756d67f42a75c564863f59b81782a3d23efc27a845d61041b,15694
+    pantry-tree:
+      sha256: 99328c298629fa921985d3de081354625463b659ca7122a1971e548d7051c68a
+      size: 33893
+  original:
+    hackage: ghc-lib-parser-9.6.2.20230523
 snapshots:
 - completed:
     sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,12 +12,12 @@ packages:
   original:
     hackage: cryptonite-0.30
 - completed:
-    hackage: libsecp256k1-0.2.0@sha256:1c64fa4f06a2681376263c8ce426339e32cdf30dd95b095c037505a1a351db95,2189
+    hackage: libsecp256k1-0.2.1@sha256:ffa0dcfcfd45125a60989a15d872aa687db1a7829fdb65c9a5e63404a2e8090f,2189
     pantry-tree:
-      sha256: 40df088f7d7b3ca61b93f08d27b0beefae6f35670fd272db69e68558df1f2d5c
+      sha256: 764ebbc62bc33ce650a920aaa1a20996861ad9d5a472c4a81b38a8771bc1df8b
       size: 902
   original:
-    hackage: libsecp256k1-0.2.0
+    hackage: libsecp256k1-0.2.1
 - completed:
     hackage: fourmolu-0.14.0.0@sha256:ba97d135f44cd5fb670dd47228ec3c65d3a886cc293a548510671c78c512c240,6755
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: fourmolu-0.8.2.0@sha256:2cc2e4b296897b14e937c6a22e1b9840699b2b7bf5021fbdc6f212376d44edb6,7469
+    hackage: fourmolu-0.14.0.0@sha256:ba97d135f44cd5fb670dd47228ec3c65d3a886cc293a548510671c78c512c240,6755
     pantry-tree:
-      sha256: e467a3bce53e6bbb71414a368369095eee13e423d093a5aff2cd128317362c3e
-      size: 143718
+      sha256: e70f2d81866ac2cb200e8ebc5372186d5bb293e253b4e51fadba2309bb40ed85
+      size: 156343
   original:
-    hackage: fourmolu-0.8.2.0
+    hackage: fourmolu-0.14.0.0
 - completed:
     hackage: cryptonite-0.30@sha256:12c85dea7be63e5ad90bcb487eb3846bf3c413347f94336fa1dede7b28f9936a,18301
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,12 +19,12 @@ packages:
   original:
     hackage: cryptonite-0.30
 - completed:
-    hackage: secp256k1-haskell-0.7.0@sha256:1585601c67d7c62c698402ffe8462de216a499608521a8136d0aa15f0a03a23f,2140
+    hackage: libsecp256k1-0.2.0@sha256:1c64fa4f06a2681376263c8ce426339e32cdf30dd95b095c037505a1a351db95,2189
     pantry-tree:
-      sha256: a7726275193ac4ef14c9d97378222d3ca494524c48354edf69214513def7d48d
-      size: 599
+      sha256: 40df088f7d7b3ca61b93f08d27b0beefae6f35670fd272db69e68558df1f2d5c
+      size: 902
   original:
-    hackage: secp256k1-haskell-0.7.0
+    hackage: libsecp256k1-0.2.0
 snapshots:
 - completed:
     sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575


### PR DESCRIPTION
Here we update the secp256k1 dependency to the new one. Turns out it revealed some bugs in that implementation!

I tried to take good care to make sure nothing broke, I would appreciate specific review around how I tweaked the taproot code using the new `PubKeyXO` construct as opposed to the newtype wrapper we used to use in this library.