### PR TITLE
Update build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,17 +46,17 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         name: Checkout
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         name: Checkout bitcoin-core/secp256k1
         with:
           repository: bitcoin-core/secp256k1
-          ref: 694ce8fb2d1fd8a3d641d7c33705691d41a2a860
+          ref: 1ad5185cd42c0636104129fcc9f6a4bf9c67cc40
           path: lib/secp256k1
 
-      - uses: haskell/actions/setup@f7b0997283589ea5a6b4f2ade6a239d70a412877
+      - uses: haskell-actions/setup@64aa5146ed5bd91f181552b8b5fbe50fbd2bd3fe
         name: Setup Haskell
         id: setup-haskell
         with:
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache
         id: cache
-        uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}
@@ -75,14 +75,15 @@ jobs:
 
       - name: Install buildtools (MacOS)
         if: matrix.os == 'macOS-latest'
-        run: brew install automake
+        run: |
+          brew install automake libtool
 
       - name: Install libsecp256k1 (Unix)
         if: matrix.os != 'windows-latest'
         working-directory: ./lib/secp256k1
         run: |
           ./autogen.sh
-          ./configure
+          ./configure --enable-module-schnorrsig --enable-module-recovery
           make
           make check
           sudo make install
@@ -95,11 +96,15 @@ jobs:
           pacman --noconfirm -Sy msys2-keyring
           pacman --noconfirm -S mingw-w64-x86_64-pkg-config
           pacman --noconfirm -S mingw-w64-x86_64-autotools
-          ./autogen.sh
-          ./configure --prefix=/mingw64
-          make
-          make check
-          make install
+          cmake -S . -B build -G "Unix Makefiles" \
+            -DCMAKE_TOOLCHAIN_FILE=../cmake/x86_64-w64-mingw32.toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/mingw64 \
+            -DENABLE_MODULE_SCHNORRSIG=ON \
+            -DENABLE_MODULE_RECOVERY=ON
+          cmake --build build --target all
+          cmake --build build --target test
+          cmake --build build --target install
         shell: stack exec -- bash {0}
 
       - name: Install dependencies

--- a/.github/workflows/fourmolu.yaml
+++ b/.github/workflows/fourmolu.yaml
@@ -32,7 +32,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         name: Checkout
-      - uses: fourmolu/fourmolu-action@d88033a61a1d2f04072cabd6a0bd1308d92238e4
+      - uses: haskell-actions/run-fourmolu@5a9f41fa092841e52e6c57dde5600e586fa766a4
         name: Run fourmolu
+        with:
+          version: "0.8.2.0"

--- a/.github/workflows/hlint.yaml
+++ b/.github/workflows/hlint.yaml
@@ -38,15 +38,15 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: "Set up HLint"
-        uses: haskell/actions/hlint-setup@v2
+        uses: haskell-actions/hlint-setup@0b0024319753ba0c8b2fa21b7018ed252aed8181
         with:
           version: "3.5"
 
       - name: "Run HLint"
-        uses: haskell/actions/hlint-run@v2
+        uses: haskell-actions/hlint-run@96199a3357287063c67606b26d533f1acb4b6c4e
         with:
           # For some reason this has to be a string containing JSON rather than a YAML sequence
           path: '[ "bitcoin/", "bitcoin-test/", "bitcoin-bench/" ]'

--- a/bitcoin-test/bitcoin-test.cabal
+++ b/bitcoin-test/bitcoin-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/bitcoin/bitcoin.cabal
+++ b/bitcoin/bitcoin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -66,7 +66,7 @@ library
   build-depends:
       array >=0.5.4.0
     , base >=4.9 && <5
-    , base16 >=0.3.0.1
+    , base16 >=1
     , binary >=0.8.8
     , bytestring >=0.10.10.0
     , containers >=0.6.2.1
@@ -76,7 +76,7 @@ library
     , memory >=0.15.0
     , murmur3 >=1.0.3
     , network >=3.1.1.1
-    , secp256k1-haskell >=0.4.0
+    , secp256k1-haskell >=0.4.0 && <1
     , split >=0.2.3.3
     , string-conversions >=0.4.0.1
     , text >=1.2.3.0

--- a/bitcoin/package.yaml
+++ b/bitcoin/package.yaml
@@ -17,7 +17,7 @@ bug-reports: http://github.com/haskell-bitcoin/bitcoin/issues
 dependencies:
   - array >= 0.5.4.0
   - base >=4.9 && <5
-  - base16 >= 0.3.0.1
+  - base16 >= 1
   - binary >= 0.8.8
   - bytestring >= 0.10.10.0
   - containers >= 0.6.2.1
@@ -28,7 +28,7 @@ dependencies:
   - murmur3 >= 1.0.3
   - network >= 3.1.1.1
   - split >= 0.2.3.3
-  - secp256k1-haskell >= 0.4.0
+  - secp256k1-haskell >= 0.4.0 && < 1
   - string-conversions >= 0.4.0.1
   - text >= 1.2.3.0
   - transformers >= 0.5.6.2

--- a/bitcoin/src/Bitcoin/Transaction/Builder.hs
+++ b/bitcoin/src/Bitcoin/Transaction/Builder.hs
@@ -273,9 +273,10 @@ verifyStdInput net tx i so0 val
     | isSegwit so0 =
         fromRight False $ (inp == mempty &&) . verifySegwitInput so0 <$> wp so0
     | otherwise =
-        fromRight False $
-            (verifyLegacyInput so0 <$> decodeInputBS net inp)
-                <|> (nestedScriptOutput >>= \so -> verifyNestedInput so0 so <$> wp so)
+        either
+            (const (fromRight False (nestedScriptOutput >>= \so -> verifyNestedInput so0 so <$> wp so)))
+            (verifyLegacyInput so0)
+            (decodeInputBS net inp)
   where
     inp = scriptInput $ txIn tx !! i
     theTxSigHash so = S.makeSigHash net tx i so val

--- a/bitcoin/src/Bitcoin/Util.hs
+++ b/bitcoin/src/Bitcoin/Util.hs
@@ -57,6 +57,7 @@ module Bitcoin.Util (
 
 import Control.Monad (replicateM)
 import Control.Monad.Trans.Except (ExceptT (..), except)
+import qualified Data.Base16.Types as B16
 import Data.Bifunctor (bimap)
 import Data.Binary (Binary, Get, Put)
 import qualified Data.Binary as Bin
@@ -106,21 +107,21 @@ hexBuilder = lazyByteStringHex
 
 
 encodeHex :: ByteString -> Text
-encodeHex = B16.encodeBase16
+encodeHex = B16.extractBase16 . B16.encodeBase16
 
 
 -- | Encode as string of human-readable hex characters.
 encodeHexLazy :: BSL.ByteString -> TL.Text
-encodeHexLazy = BL16.encodeBase16
+encodeHexLazy = B16.extractBase16 . BL16.encodeBase16
 
 
 decodeHex :: Text -> Maybe ByteString
-decodeHex = eitherToMaybe . B16.decodeBase16 . E.encodeUtf8
+decodeHex = eitherToMaybe . B16.decodeBase16Untyped . E.encodeUtf8
 
 
 -- | Decode string of human-readable hex characters.
 decodeHexLazy :: TL.Text -> Maybe BSL.ByteString
-decodeHexLazy = eitherToMaybe . BL16.decodeBase16 . EL.encodeUtf8
+decodeHexLazy = eitherToMaybe . BL16.decodeBase16Untyped . EL.encodeUtf8
 
 
 -- | Obtain 'Int' bits from beginning of 'ByteString'. Resulting 'ByteString'
@@ -153,7 +154,7 @@ maybeToEither err = maybe (Left err) Right
 
 
 -- | Lift a 'Maybe' computation into the 'ExceptT' monad.
-liftMaybe :: Monad m => b -> Maybe a -> ExceptT b m a
+liftMaybe :: (Monad m) => b -> Maybe a -> ExceptT b m a
 liftMaybe err = except . maybeToEither err
 
 
@@ -243,11 +244,11 @@ convertBits pad frombits tobits i = (reverse yout, rem')
 -- Serialization helpers
 --
 
-encodeS :: Binary a => a -> ByteString
+encodeS :: (Binary a) => a -> ByteString
 encodeS = BSL.toStrict . Bin.encode
 
 
-decode :: Binary a => BSL.ByteString -> Either String a
+decode :: (Binary a) => BSL.ByteString -> Either String a
 decode = bimap lst3 lst3 . Get.decodeOrFail
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.27
+resolver: lts-22.6
 system-ghc: true
 nix:
   packages:
@@ -7,6 +7,7 @@ nix:
 extra-deps:
   - fourmolu-0.8.2.0
   - cryptonite-0.30
+  - secp256k1-haskell-0.7.0
 packages:
   - ./bitcoin
   - ./bitcoin-test

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,9 +18,16 @@ packages:
       size: 23323
   original:
     hackage: cryptonite-0.30
+- completed:
+    hackage: secp256k1-haskell-0.7.0@sha256:1585601c67d7c62c698402ffe8462de216a499608521a8136d0aa15f0a03a23f,2140
+    pantry-tree:
+      sha256: a7726275193ac4ef14c9d97378222d3ca494524c48354edf69214513def7d48d
+      size: 599
+  original:
+    hackage: secp256k1-haskell-0.7.0
 snapshots:
 - completed:
-    sha256: 1ecad1f0bd2c27de88dbff6572446cfdf647c615d58a7e2e2085c6b7dfc04176
-    size: 619403
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/27.yaml
-  original: lts-19.27
+    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
+    size: 714100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
+  original: lts-22.6


### PR DESCRIPTION
This commit updates the build to pass on the latest github runners. To this end we:
* update the github workflows to use the latest versions of all actions
* update bitcoin-core/libsecp256k1 to 0.4.1
* enable the schnorr signature and the recovery module in the installation of the `secp256k1` library on all platforms to resolve any issues with missing symbols
* update the stackage resolver to version lts-22.6 - the macOS runner has issues building on GHC 9.0.X
* did not upgrade but added lower bounds to the `secp256k1-haskell` dependency of `< 1` as presumably we plan to move to the new `libsecp256k1` library
* small changes `Bitcoin.Transaction.Builder` and `Bitcoin.Util` to make the code compile with the latest version of `bytestring` and remove the reliance on a missing (likely orphan) instances of `Alternative` for `Either a`.